### PR TITLE
Introducing Basic Playground

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,11 @@
         "ext-calendar": "*"
     },
     "require-dev": {
+        "laravel/prompts": "^0.1.15",
         "pestphp/pest": "^2.31",
         "phpstan/phpstan": "^1.10.56",
-        "spatie/ray": "^1.40.1"
+        "spatie/ray": "^1.40.1",
+        "symfony/var-dumper": "^6.4"
     },
     "autoload": {
         "psr-4": {

--- a/playground.php
+++ b/playground.php
@@ -1,0 +1,30 @@
+<?php
+
+use Spatie\Holidays\Countries\Country;
+use Spatie\Holidays\Holidays;
+use function Laravel\Prompts\select;
+
+require __DIR__ . '/vendor/autoload.php';
+
+$countries = [];
+
+foreach (glob(__DIR__.'/src/Countries/*.php') as $filename) { // @phpstan-ignore-line
+    $countryClass = '\\Spatie\\Holidays\\Countries\\' . basename($filename, '.php');
+
+    if (basename($filename) === 'Country.php') {
+        continue;
+    }
+
+    $countries[$countryClass] = str_replace('\\Spatie\\Holidays\\Countries\\', '', $countryClass);
+}
+
+/** @var Country $class */
+$class = select('Select a country', $countries);
+
+$result = collect(Holidays::for($class::make())->get())
+    ->map(fn (array $holiday) => [
+        'name' => $holiday['name'],
+        'date' => $holiday['date']->format('Y-m-d'), // @phpstan-ignore-line
+    ])->toArray();
+
+dd($result);


### PR DESCRIPTION
This pull request uses `laravel/prompts` and `symfony/var-dumper` to introduce a basic playground:

![CleanShot 2024-01-17 at 15 19 52](https://github.com/spatie/holidays/assets/60591772/8ee4c784-c494-4aab-9bde-a60ad766e155)

Result:

![CleanShot 2024-01-17 at 15 20 06](https://github.com/spatie/holidays/assets/60591772/a0833787-76cb-4e6a-adb3-3cdf39e53db8)
