### PR TITLE
Add South African holidays

### DIFF
--- a/src/Countries/SouthAfrica.php
+++ b/src/Countries/SouthAfrica.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+
+class SouthAfrica extends Country
+{
+
+    public function countryCode(): string
+    {
+        return 'za';
+    }
+
+    /** @return array<string, string|CarbonImmutable> */
+    protected function allHolidays(int $year): array
+    {
+        // https://www.gov.za/about-sa/public-holidays
+        $standardDates = [
+            'New Year\'s Day' => '01-01',
+            'Human Rights Day' => '03-21',
+            'Freedom Day' => '04-27',
+            'Workers\' Day' => '05-01',
+            'Youth Day' => '06-16',
+            'National Women\'s Day' => '08-09',
+            'Heritage Day' => '09-24',
+            'Day of Reconciliation' => '12-16',
+            'Christmas Day' => '12-25',
+            'Day of Goodwill' => '12-26',
+        ];
+
+        $observedDates = [];
+        foreach ($standardDates as $name => $standardDate) {
+            $date = CarbonImmutable::createFromFormat('Y-m-d', "{$year}-{$standardDate}");
+            if ($date && $date->isSunday()) {
+                // Public Holidays that fall on Sundays are observed on the following Monday.
+                $observedDates["{$name} Observed"] = $date->addDay();
+            }
+        }
+
+        return array_merge($standardDates, $observedDates, $this->variableHolidays($year));
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function variableHolidays(int $year): array
+    {
+        $easter = CarbonImmutable::createFromTimestamp(easter_date($year))
+            ->setTimezone('Africa/Johannesburg');
+
+        return [
+            'Good Friday' => $easter->subDays(2),
+            'Family Day' => $easter->addDay(),
+        ];
+    }
+}

--- a/tests/.pest/snapshots/Countries/SouthAfricaTest/it_can_calculate_South_African_holidays.snap
+++ b/tests/.pest/snapshots/Countries/SouthAfricaTest/it_can_calculate_South_African_holidays.snap
@@ -1,0 +1,54 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Human Rights Day",
+        "date": "2024-03-21"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2024-03-29"
+    },
+    {
+        "name": "Family Day",
+        "date": "2024-04-01"
+    },
+    {
+        "name": "Freedom Day",
+        "date": "2024-04-27"
+    },
+    {
+        "name": "Workers' Day",
+        "date": "2024-05-01"
+    },
+    {
+        "name": "Youth Day",
+        "date": "2024-06-16"
+    },
+    {
+        "name": "Youth Day Observed",
+        "date": "2024-06-17"
+    },
+    {
+        "name": "National Women's Day",
+        "date": "2024-08-09"
+    },
+    {
+        "name": "Heritage Day",
+        "date": "2024-09-24"
+    },
+    {
+        "name": "Day of Reconciliation",
+        "date": "2024-12-16"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2024-12-25"
+    },
+    {
+        "name": "Day of Goodwill",
+        "date": "2024-12-26"
+    }
+]

--- a/tests/Countries/SouthAfricaTest.php
+++ b/tests/Countries/SouthAfricaTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Holidays\Tests\Countries;
+
+use Carbon\CarbonImmutable;
+use Spatie\Holidays\Holidays;
+
+it('can calculate South African holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2024-01-01');
+
+    $holidays = Holidays::for(country: 'za')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+});


### PR DESCRIPTION
This PR adds South African public holidays, taking into account the law which states that if a public holiday lands on a Sunday then it is also observed the following Monday.