### PR TITLE
Add malaysian holidays

### DIFF
--- a/src/Countries/Malaysia.php
+++ b/src/Countries/Malaysia.php
@@ -40,6 +40,7 @@ class Malaysia extends Country
             'Hari Raya Haji Hari Kedua' => $this->islamicCalendar('11/12', $year),
             'Maulidur Rasul' => $this->islamicCalendar('12/03', $year, true),
             'Awal Muharram' => $this->islamicCalendar('01/01', $year, true),
+            'Hari Keputeraan YDP Agong' => $this->getYDPAgongBirthday($year),
         ];
     }
 
@@ -88,5 +89,14 @@ class Malaysia extends Country
         $dateTime = DateTime::createFromFormat('d/m/Y', '01/01/' . ($nextYear ? $year + 1 : $year));
 
         return (int) $formatter->format($dateTime);
+    }
+
+    protected function getYDPAgongBirthday($year)
+    {
+        return match (true) {
+            in_array($year, range(2017, 2019)) => '09-09',
+            in_array($year, range(2020, 2026)) => new CarbonImmutable("first monday of june {$year}", $this->timezone),
+            default => null
+        };
     }
 }

--- a/src/Countries/Malaysia.php
+++ b/src/Countries/Malaysia.php
@@ -94,6 +94,7 @@ class Malaysia extends Country
     protected function getYDPAgongBirthday($year)
     {
         return match (true) {
+            in_array($year, range(1958, 2016)) => new CarbonImmutable("first saturday of june {$year}", $this->timezone),
             in_array($year, range(2017, 2019)) => '09-09',
             in_array($year, range(2020, 2026)) => new CarbonImmutable("first monday of june {$year}", $this->timezone),
             default => null

--- a/src/Countries/Malaysia.php
+++ b/src/Countries/Malaysia.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+use DateTime;
+use DateTimeZone;
+use IntlDateFormatter;
+
+class Malaysia extends Country
+{
+    protected string $timezone = 'Asia/Kuala_Lumpur';
+
+    public function countryCode(): string
+    {
+        return 'ms';
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function allHolidays(int $year): array
+    {
+        return array_merge([
+            'Tahun Baru' => '01-01',
+            'Hari Pekerja' => '05-01',
+            'Hari Kebangsaan' => '08-31',
+            'Hari Malaysia' => '09-16',
+            'Hari Krismas' => '12-25',
+        ], $this->variableHolidays($year));
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function variableHolidays(int $year): array
+    {
+        return [
+            'Tahun Baru Cina' => $this->chineseCalendar('01/01', $year),
+            'Tahun Baru Cina Hari Kedua' => $this->chineseCalendar('01/02', $year),
+            'Hari Raya Aidilfitri' => $this->islamicCalendar('01/10', $year),
+            'Hari Raya Aidilfitri Hari Kedua' => $this->islamicCalendar('02/10', $year),
+            'Hari Raya Haji' => $this->islamicCalendar('10/12', $year),
+            'Hari Raya Haji Hari Kedua' => $this->islamicCalendar('11/12', $year),
+            'Maulidur Rasul' => $this->islamicCalendar('12/03', $year, true),
+            'Awal Muharram' => $this->islamicCalendar('01/01', $year, true),
+        ];
+    }
+
+    protected function chineseCalendar(string $input, int $year): string
+    {
+        $formatter = new IntlDateFormatter(
+            locale: 'zh-CN@calendar=chinese',
+            dateType: IntlDateFormatter::SHORT,
+            timeType: IntlDateFormatter::NONE,
+            timezone: $this->timezone,
+            calendar: IntlDateFormatter::TRADITIONAL
+        );
+
+        $timeStamp = $formatter->parse($year . '/' . $input);
+        $dateTime = date_create()->setTimeStamp($timeStamp)->setTimezone(new DateTimeZone($this->timezone));
+
+        return $dateTime->format('m-d');
+    }
+
+    protected function islamicCalendar(string $input, int $year, $nextYear = false): string
+    {
+        $hijrYear = $this->getHijriYear(year: $year, nextYear: $nextYear);
+        $formatter = $this->getIslamicFormatter();
+
+        $timeStamp = $formatter->parse($input . '/' . $hijrYear . ' AH');
+        $dateTime = date_create()->setTimeStamp($timeStamp)->setTimezone(new DateTimeZone('Asia/Kuala_Lumpur'));
+
+        return $dateTime->format('m-d');
+    }
+
+    protected function getIslamicFormatter()
+    {
+        return new IntlDateFormatter(
+            locale: 'ms_MY@calendar=islamic-civil',
+            dateType: IntlDateFormatter::MEDIUM,
+            timeType: IntlDateFormatter::NONE,
+            timezone: $this->timezone,
+            calendar: IntlDateFormatter::TRADITIONAL
+        );
+    }
+
+    protected function getHijriYear(int $year, $nextYear = false): int
+    {
+        $formatter = $this->getIslamicFormatter();
+        $formatter->setPattern('yyyy');
+        $dateTime = DateTime::createFromFormat('d/m/Y', '01/01/' . ($nextYear ? $year + 1 : $year));
+
+        return (int) $formatter->format($dateTime);
+    }
+}

--- a/tests/.pest/snapshots/Countries/MalaysiaTest/it_can_calculate_malaysian_holidays.snap
+++ b/tests/.pest/snapshots/Countries/MalaysiaTest/it_can_calculate_malaysian_holidays.snap
@@ -1,0 +1,54 @@
+[
+    {
+        "name": "Tahun Baru",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Tahun Baru Cina",
+        "date": "2024-02-10"
+    },
+    {
+        "name": "Tahun Baru Cina Hari Kedua",
+        "date": "2024-02-11"
+    },
+    {
+        "name": "Hari Raya Aidilfitri",
+        "date": "2024-04-10"
+    },
+    {
+        "name": "Hari Raya Aidilfitri Hari Kedua",
+        "date": "2024-04-11"
+    },
+    {
+        "name": "Hari Pekerja",
+        "date": "2024-05-01"
+    },
+    {
+        "name": "Hari Raya Haji",
+        "date": "2024-06-17"
+    },
+    {
+        "name": "Hari Raya Haji Hari Kedua",
+        "date": "2024-06-18"
+    },
+    {
+        "name": "Awal Muharram",
+        "date": "2024-07-08"
+    },
+    {
+        "name": "Hari Kebangsaan",
+        "date": "2024-08-31"
+    },
+    {
+        "name": "Hari Malaysia",
+        "date": "2024-09-16"
+    },
+    {
+        "name": "Maulidur Rasul",
+        "date": "2024-09-16"
+    },
+    {
+        "name": "Hari Krismas",
+        "date": "2024-12-25"
+    }
+]

--- a/tests/.pest/snapshots/Countries/MalaysiaTest/it_can_calculate_malaysian_holidays.snap
+++ b/tests/.pest/snapshots/Countries/MalaysiaTest/it_can_calculate_malaysian_holidays.snap
@@ -24,6 +24,10 @@
         "date": "2024-05-01"
     },
     {
+        "name": "Hari Keputeraan YDP Agong",
+        "date": "2024-06-03"
+    },
+    {
         "name": "Hari Raya Haji",
         "date": "2024-06-17"
     },

--- a/tests/Countries/MalaysiaTest.php
+++ b/tests/Countries/MalaysiaTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\Holidays\Tests\Countries;
+
+use Spatie\Holidays\Holidays;
+
+it('can calculate malaysian holidays', function () {
+    $holidays = Holidays::for(country: 'ms')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+});


### PR DESCRIPTION
This PR is to add the [federal holidays for Malaysia.](https://en.wikipedia.org/wiki/Public_holidays_in_Malaysia#:~:text=Each%20state%20and%20federal%20territory,Sarawak%20which%20observes%2013%20days.) Malaysia observes 14 days of federal holidays.

- [x] [Prophet Muhammad's Birthday](https://en.wikipedia.org/wiki/Mawlid) (Maulidur Rasul)
- [x] [Hari Merdeka](https://en.wikipedia.org/wiki/Independence_Day_(Malaysia)) (Hari Kebangsaan)
- [x] [Chinese New Year](https://en.wikipedia.org/wiki/Chinese_New_Year) (Tahun Baru Cina) (one day in Kelantan and Terengganu, two days in rest of the country)
- [ ] [Wesak Day](https://en.wikipedia.org/wiki/Vesak)
- [x] [The Yang di-Pertuan Agong Official Birthday](https://en.wikipedia.org/wiki/Yang_di-Pertuan_Agong) (Hari Keputeraan YDP Agong)
- [x] [Hari Raya Puasa](https://en.wikipedia.org/wiki/Eid_al-Fitr) (Hari Raya Aidilfitri) (two days)
- [x] [Hari Raya Qurban](https://en.wikipedia.org/wiki/Eid_al-Adha) (Hari Raya Aidiladha) (two days in Kelantan and Terengganu, one day in rest of the country)
- [ ] [Deepavali](https://en.wikipedia.org/wiki/Deepavali) (except Sarawak)
- [x] [Christmas](https://en.wikipedia.org/wiki/Christmas) (Hari Krismas)
- [x] [Labour Day](https://en.wikipedia.org/wiki/Labour_Day) (Hari Pekerja)
- [x] [Awal Muharram](https://en.wikipedia.org/wiki/Awal_Muharram) (Maulidur Rasul)
- [x] [Malaysia Day](https://en.wikipedia.org/wiki/Malaysia_Day) (Hari Malaysia)

States holidays not included in this PR. Will add states holidays when #37 (or similar) is merged.