### PR TITLE
Add English Holidays

### DIFF
--- a/src/Countries/England.php
+++ b/src/Countries/England.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+
+class England extends Country
+{
+  public function countryCode(): string
+  {
+    return 'en';
+  }
+
+  protected function allHolidays(int $year): array
+  {
+    return array_merge([
+      'New Year\'s Day' => new CarbonImmutable($year . "-01-01", 'Europe/London'),
+      'Early May bank holiday' => new CarbonImmutable("first monday of may {$year}", 'Europe/London'),
+      'Spring bank holiday' => new CarbonImmutable("last monday of may {$year}", 'Europe/London'),
+      'Summer bank holiday' => new CarbonImmutable("last monday of august {$year}", 'Europe/London'),
+      'Christmas Day' => new CarbonImmutable($year . "-12-25", 'Europe/London'),
+      'Boxing Day' => new CarbonImmutable($year . "-12-26", 'Europe/London'),
+    ], $this->variableHolidays($year));
+  }
+
+  protected function variableHolidays(int $year): array
+  {
+    $easterSunday = CarbonImmutable::createFromTimestamp(easter_date($year))
+      ->setTimezone('Europe/London');
+
+    $goodFriday = $easterSunday->subDays(2);
+    $easterMonday = $easterSunday->addDays(1);
+
+    return [
+      'Good Friday' => $goodFriday,
+      'Easter Monday' => $easterMonday,
+    ];
+  }
+}

--- a/tests/.pest/snapshots/Countries/EnglandTest/it_can_calculate_english_holidays.snap
+++ b/tests/.pest/snapshots/Countries/EnglandTest/it_can_calculate_english_holidays.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2024-03-29"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2024-04-01"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2024-05-06"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2024-05-27"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2024-08-26"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2024-12-25"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2024-12-26"
+    }
+]

--- a/tests/Countries/EnglandTest.php
+++ b/tests/Countries/EnglandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spati\Holidays\Countries;
+namespace Spatie\Holidays\Countries;
 
 use Carbon\CarbonImmutable;
 use Spatie\Holidays\Holidays;

--- a/tests/Countries/EnglandTest.php
+++ b/tests/Countries/EnglandTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spati\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+use Spatie\Holidays\Holidays;
+
+it('can calculate english holidays', function () {
+  CarbonImmutable::setTestNowAndTimezone('2024-01-01');
+
+  $holidays = Holidays::for(country: 'en')->get();
+
+  expect($holidays)->toBeArray()->not()->toBeEmpty();
+
+  expect(formatDates($holidays))->toMatchSnapshot();
+});


### PR DESCRIPTION
This adds the English & Welsh holidays according to the Gov website: https://www.gov.uk/bank-holidays