### PR TITLE
Add Dia da Consciência Negra as holiday in Brazil

### DIFF
--- a/src/Countries/Brazil.php
+++ b/src/Countries/Brazil.php
@@ -22,6 +22,7 @@ class Brazil extends Country
             'Nossa Senhora Aparecida' => '10-12',
             'Finados' => '11-02',
             'Proclamação da República' => '11-15',
+            'Dia da Consciência Negra' => '11-20',
             'Natal' => '12-25',
         ], $this->variableHolidays($year));
     }

--- a/tests/.pest/snapshots/Countries/BrazilTest/it_can_calculate_brazil_holidays.snap
+++ b/tests/.pest/snapshots/Countries/BrazilTest/it_can_calculate_brazil_holidays.snap
@@ -40,6 +40,10 @@
         "date": "2024-11-15"
     },
     {
+        "name": "Dia da Consci\u00eancia Negra",
+        "date": "2024-11-20"
+    },
+    {
         "name": "Natal",
         "date": "2024-12-25"
     }


### PR DESCRIPTION
A new law published in last 21 December, determine November 20 as "Dia da Consciência Negra" national holiday in Brazil.

Sources: https://www12.senado.leg.br/noticias/materias/2023/12/22/dia-da-consciencia-negra-se-torna-feriado-nacional

https://normas.leg.br/?urn=urn:lex:br:federal:lei:2023-12-21;14759