### PR TITLE
add Philippines

### DIFF
--- a/src/Countries/Philippines.php
+++ b/src/Countries/Philippines.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+
+class Philippines extends Country
+{
+    public function countryCode(): string
+    {
+        return 'ph';
+    }
+
+    protected function allHolidays(int $year): array
+    {
+         return array_merge([
+            'New Year\'s Day' => '01-01',
+            'Araw ng Kagitingan' => '04-01',
+            'Labor Day' => '05-01',
+            'Independence Day' => '06-12',
+            'National Heroes Day' => '08-26',
+            'Bonifacio Day' => '11-30',
+            'Christmas Day' => '12-25',
+            'Rizal Day' => '12-30',
+        ], $this->variableHolidays($year));
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function variableHolidays(int $year): array
+    {
+        $easter = CarbonImmutable::createFromTimestamp(easter_date($year))
+            ->setTimezone('Asia/Manila');
+
+        return [
+            'Maundy Thursday' => $easter->subDays(3),
+            'Good Friday' => $easter->subDays(2),
+        ];
+    }
+}

--- a/tests/.pest/snapshots/Countries/PhilippinesTest/it_can_calculate_philippine_holidays.snap
+++ b/tests/.pest/snapshots/Countries/PhilippinesTest/it_can_calculate_philippine_holidays.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Maundy Thursday",
+        "date": "2024-03-28"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2024-03-29"
+    },
+    {
+        "name": "Araw ng Kagitingan",
+        "date": "2024-04-01"
+    },
+    {
+        "name": "Labor Day",
+        "date": "2024-05-01"
+    },
+    {
+        "name": "Independence Day",
+        "date": "2024-06-12"
+    },
+    {
+        "name": "National Heroes Day",
+        "date": "2024-08-26"
+    },
+    {
+        "name": "Bonifacio Day",
+        "date": "2024-11-30"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2024-12-25"
+    },
+    {
+        "name": "Rizal Day",
+        "date": "2024-12-30"
+    }
+]

--- a/tests/Countries/PhilippinesTest.php
+++ b/tests/Countries/PhilippinesTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Holidays\Tests\Countries;
+
+use Carbon\CarbonImmutable;
+use Spatie\Holidays\Holidays;
+
+it('can calculate philippine holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2024-01-01');
+
+    $holidays = Holidays::for(country: 'ph')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+
+});


### PR DESCRIPTION
Added regular holidays, this doesn't include Special (Non-working) holidays. [Official Gazette](https://www.officialgazette.gov.ph/nationwide-holidays/)

** Special (Non-working) holidays** changes from time to time, not sure if I need to add, probably in the future.