### PR TITLE
fix: Oudjaarsdag is not a public holiday

### DIFF
--- a/src/Countries/Netherlands.php
+++ b/src/Countries/Netherlands.php
@@ -19,7 +19,6 @@ class Netherlands extends Country
             'Bevrijdingsdag' => '05-05',
             '1e Kerstdag' => '12-25',
             '2e Kerstdag' => '12-26',
-            'Oudejaarsdag' => '12-31',
         ], $this->variableHolidays($year));
     }
 


### PR DESCRIPTION
Oudjaarsdag is not a public holiday and therefor should be removed.
https://www.rijksoverheid.nl/onderwerpen/arbeidsovereenkomst-en-cao/vraag-en-antwoord/officiele-feestdagen