### PR TITLE
Added Kenyan holidays

### DIFF
--- a/src/Countries/Kenya.php
+++ b/src/Countries/Kenya.php
@@ -11,7 +11,6 @@ class Kenya extends Country
         return 'ke';
     }
 
-    /** @return array<string, CarbonImmutable|string> */
     protected function allHolidays(int $year): array
     {
         return array_merge([

--- a/src/Countries/Kenya.php
+++ b/src/Countries/Kenya.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+
+class Kenya extends Country
+{
+    public function countryCode(): string
+    {
+        return 'ke';
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function allHolidays(int $year): array
+    {
+        return array_merge([
+            "New Year's" => "01-01",
+            "Labour" => "05-01",
+            "Madaraka" => "06-01",
+            "Mashujaa" => "10-20",
+            "Jamhuri" => "12-01",
+            "Christmas" => "12-25",
+            "Boxing" => "12-26",
+        ], $this->variableHolidays($year));
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function variableHolidays(int $year): array
+    {
+        $easter = CarbonImmutable::createFromTimestamp(easter_date($year))
+            ->setTimezone('Africa/Nairobi');
+
+        return [];
+    }
+}

--- a/src/Countries/Kenya.php
+++ b/src/Countries/Kenya.php
@@ -11,7 +11,7 @@ class Kenya extends Country
         return 'ke';
     }
 
-    /** @return array<string, CarbonImmutable> */
+    /** @return array<string, CarbonImmutable|string> */
     protected function allHolidays(int $year): array
     {
         return array_merge([

--- a/src/Countries/Kenya.php
+++ b/src/Countries/Kenya.php
@@ -18,6 +18,7 @@ class Kenya extends Country
             "New Year's" => "01-01",
             "Labour" => "05-01",
             "Madaraka" => "06-01",
+            "Utamaduni" => "10-10",
             "Mashujaa" => "10-20",
             "Jamhuri" => "12-01",
             "Christmas" => "12-25",
@@ -31,6 +32,9 @@ class Kenya extends Country
         $easter = CarbonImmutable::createFromTimestamp(easter_date($year))
             ->setTimezone('Africa/Nairobi');
 
-        return [];
+        return [
+            "Good Friday" => $easter->subDays(2),
+            "Easter Monday" => $easter->addDay(),
+        ];
     }
 }

--- a/tests/.pest/snapshots/Countries/KenyaTest/it_can_calculate_kenyan_holidays.snap
+++ b/tests/.pest/snapshots/Countries/KenyaTest/it_can_calculate_kenyan_holidays.snap
@@ -1,0 +1,30 @@
+[
+    {
+        "name": "New Year's",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Labour",
+        "date": "2024-05-01"
+    },
+    {
+        "name": "Madaraka",
+        "date": "2024-06-01"
+    },
+    {
+        "name": "Mashujaa",
+        "date": "2024-10-20"
+    },
+    {
+        "name": "Jamhuri",
+        "date": "2024-12-01"
+    },
+    {
+        "name": "Christmas",
+        "date": "2024-12-25"
+    },
+    {
+        "name": "Boxing",
+        "date": "2024-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/KenyaTest/it_can_calculate_kenyan_holidays.snap
+++ b/tests/.pest/snapshots/Countries/KenyaTest/it_can_calculate_kenyan_holidays.snap
@@ -4,12 +4,24 @@
         "date": "2024-01-01"
     },
     {
+        "name": "Good Friday",
+        "date": "2024-03-29"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2024-04-01"
+    },
+    {
         "name": "Labour",
         "date": "2024-05-01"
     },
     {
         "name": "Madaraka",
         "date": "2024-06-01"
+    },
+    {
+        "name": "Utamaduni",
+        "date": "2024-10-10"
     },
     {
         "name": "Mashujaa",

--- a/tests/Countries/KenyaTest.php
+++ b/tests/Countries/KenyaTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Holidays\Tests\Countries;
+
+use Carbon\CarbonImmutable;
+use Spatie\Holidays\Holidays;
+
+it('can calculate kenyan holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2024-01-01');
+
+    $holidays = Holidays::for(country: 'ke')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+});


### PR DESCRIPTION
Adds Kenya's recognized holidays 

> [!NOTE]
> The holidays of Idd-ul-Fitr, Idd-ul-Azha and Diwali are based on the appearance of the moon, hence not added