### PR TITLE
Add El Salvador Holidays

### DIFF
--- a/src/Countries/ElSalvador.php
+++ b/src/Countries/ElSalvador.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+
+class ElSalvador extends Country
+{
+
+    public function countryCode(): string
+    {
+        return 'sv';
+    }
+
+    protected function allHolidays(int $year): array
+    {
+        return array_merge([
+            'Año Nuevo' => '01-01',
+            'Día del Trabajo' => '05-01',
+            'Día de la Madre' => '05-10',
+            'Día del Padre' => '06-17',
+            'Fiesta Divino Salvador del Mundo' => '08-06',
+            'Día de la Independencia' => '09-15',
+            'Día de Los Difuntos' => '11-02',
+            'Navidad' => '12-25',
+        ], $this->variableHolidays($year));
+    }
+
+    /** @return array<string, CarbonImmutable*/
+    protected function variableHolidays(int $year): array
+    {
+        $easter = CarbonImmutable::createFromTimestamp(easter_date($year))
+            ->setTimezone('America/El_Salvador');
+
+        return [
+            'Jueves Santo' => $easter->subDays(3),
+            'Viernes Santo' => $easter->subDays(2),
+            'Sábado de Gloria' => $easter->subDays(1),
+        ];
+    }
+}

--- a/src/Countries/ElSalvador.php
+++ b/src/Countries/ElSalvador.php
@@ -26,7 +26,7 @@ class ElSalvador extends Country
         ], $this->variableHolidays($year));
     }
 
-    /** @return array<string, CarbonImmutable*/
+    /** @return array<string, CarbonImmutable> */
     protected function variableHolidays(int $year): array
     {
         $easter = CarbonImmutable::createFromTimestamp(easter_date($year))

--- a/tests/.pest/snapshots/Countries/ElSalvadorTest/it_can_calculate_el_salvador_holidays.snap
+++ b/tests/.pest/snapshots/Countries/ElSalvadorTest/it_can_calculate_el_salvador_holidays.snap
@@ -1,0 +1,46 @@
+[
+    {
+        "name": "A\u00f1o Nuevo",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Jueves Santo",
+        "date": "2024-03-27"
+    },
+    {
+        "name": "Viernes Santo",
+        "date": "2024-03-28"
+    },
+    {
+        "name": "S\u00e1bado de Gloria",
+        "date": "2024-03-29"
+    },
+    {
+        "name": "D\u00eda del Trabajo",
+        "date": "2024-05-01"
+    },
+    {
+        "name": "D\u00eda de la Madre",
+        "date": "2024-05-10"
+    },
+    {
+        "name": "D\u00eda del Padre",
+        "date": "2024-06-17"
+    },
+    {
+        "name": "Fiesta Divino Salvador del Mundo",
+        "date": "2024-08-06"
+    },
+    {
+        "name": "D\u00eda de la Independencia",
+        "date": "2024-09-15"
+    },
+    {
+        "name": "D\u00eda de Los Difuntos",
+        "date": "2024-11-02"
+    },
+    {
+        "name": "Navidad",
+        "date": "2024-12-25"
+    }
+]

--- a/tests/Countries/ElSalvadorTest.php
+++ b/tests/Countries/ElSalvadorTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Holidays\Tests\Countries;
+
+use Carbon\CarbonImmutable;
+use Spatie\Holidays\Holidays;
+
+it('can calculate el salvador holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2024-01-01');
+
+    $holidays = Holidays::for(country: 'sv')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+});


### PR DESCRIPTION
This Pull Request introduces support for the Salvadorean holidays.

The test was created with your snap, and it passed the PhpStan.

Sources:
https://sv.usembassy.gov/es/holiday-calendar-es/
https://www.laprensagrafica.com/salvadorenisimo/Vacaciones-2024-estas-son-las-fechas-de-asuetos-en-El-Salvador-20240102-0048.html