### PR TITLE
Add Singapore Public Holiday

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
     "require": {
         "php": "^8.1",
         "ext-intl": "*",
-        "nesbot/carbon": "^2.72.1|^3.0"
+        "nesbot/carbon": "^2.72.1|^3.0",
+        "ext-calendar": "*",
+        "solaris/php-moon-phase": "^2.1"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/src/Calendars/ChineseCalendar.php
+++ b/src/Calendars/ChineseCalendar.php
@@ -9,6 +9,7 @@ use IntlDateFormatter;
 trait ChineseCalendar
 {
     protected string $chineseCalendarTimezone = 'Asia/Shanghai';
+    protected string $chineseLocale = 'zh-SG';
 
     public function setChineseCalendarTimezone(string $chineseCalendarTimezone): static
     {
@@ -17,19 +18,26 @@ trait ChineseCalendar
         return $this;
     }
 
+    public function setChineseLocale(string $chineseLocale): static
+    {
+        $this->chineseLocale = $chineseLocale;
+
+        return $this;
+    }
+
     protected function chineseToGregorianDate(string $input, int $year): CarbonImmutable
     {
-        $timestamp = (int) $this->getFormatter()->parse($year.'-'.$input);
+        $timestamp = (int) $this->getChineseFormatter()->parse($year.'-'.$input);
 
         return (new CarbonImmutable())
             ->setTimeStamp($timestamp)
             ->setTimezone(new DateTimeZone($this->chineseCalendarTimezone));
     }
 
-    protected function getFormatter(): IntlDateFormatter
+    protected function getChineseFormatter(): IntlDateFormatter
     {
         return new IntlDateFormatter(
-            locale: 'zh-CN@calendar=chinese',
+            locale: $this->chineseLocale . '@calendar=chinese',
             dateType: IntlDateFormatter::SHORT,
             timeType: IntlDateFormatter::NONE,
             timezone: $this->chineseCalendarTimezone,

--- a/src/Calendars/IndianCalendar.php
+++ b/src/Calendars/IndianCalendar.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Spatie\Holidays\Calendars;
+
+use Carbon\CarbonImmutable;
+use DateTimeZone;
+use IntlDateFormatter;
+
+trait IndianCalendar
+{
+    protected string $indianCalendarTimezone = 'Asia/Singapore';
+    protected string $indianLocale = 'zh-IN';
+
+    public function setIndianCalendarTimezone(string $indianCalendarTimezone): static
+    {
+        $this->indianCalendarTimezone = $indianCalendarTimezone;
+
+        return $this;
+    }
+
+    public function setIndianLocale(string $indianLocale): static
+    {
+        $this->indianLocale = $indianLocale;
+
+        return $this;
+    }
+
+    protected function indianToGregorianDate(string $input, int $year): CarbonImmutable
+    {
+        $timestamp = (int) $this->getIndianFormatter()->parse($year.'-'.$input);
+
+        return (new CarbonImmutable())
+            ->setTimeStamp($timestamp)
+            ->setTimezone(new DateTimeZone($this->indianCalendarTimezone));
+    }
+
+    protected function getIndianFormatter(): IntlDateFormatter
+    {
+        return new IntlDateFormatter(
+            locale: $this->indianLocale . '@calendar=indian',
+            dateType: IntlDateFormatter::SHORT,
+            timeType: IntlDateFormatter::NONE,
+            timezone: $this->indianCalendarTimezone,
+            calendar: IntlDateFormatter::TRADITIONAL
+        );
+    }
+
+}

--- a/src/Calendars/IslamicCalendar.php
+++ b/src/Calendars/IslamicCalendar.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Spatie\Holidays\Calendars;
+
+use Carbon\CarbonImmutable;
+use DateTimeZone;
+use IntlDateFormatter;
+
+trait IslamicCalendar
+{
+    protected string $islamicCalendarTimezone = 'Asia/Singapore';
+    protected string $islamicLocale = 'en-SG';
+
+    public function setIslamicCalendarTimezone(string $islamicCalendarTimezone): static
+    {
+        $this->islamicCalendarTimezone = $islamicCalendarTimezone;
+
+        return $this;
+    }
+
+    public function setIslamicLocale(string $islamicLocale): static
+    {
+        $this->islamicLocale = $islamicLocale;
+
+        return $this;
+    }
+
+    protected function islamicToGregorianDate(string $input, int $year, int $nextYear = 0): CarbonImmutable
+    {
+        $hijriYear = $this->getHijriYear(year: $year, nextYear: $nextYear);
+        
+        $timestamp = (int) $this->getIslamicFormatter()->parse($input . '/' . $hijriYear . ' AH');
+
+        return (new CarbonImmutable())
+            ->setTimeStamp($timestamp)
+            ->setTimezone(new DateTimeZone($this->islamicCalendarTimezone));
+    }
+
+    protected function getIslamicFormatter(): IntlDateFormatter
+    {
+        return new IntlDateFormatter(
+            locale: $this->islamicLocale . '@calendar=islamic-civil',
+            dateType: IntlDateFormatter::MEDIUM,
+            timeType: IntlDateFormatter::NONE,
+            timezone: $this->islamicCalendarTimezone,
+            calendar: IntlDateFormatter::TRADITIONAL
+        );
+    }
+    
+    protected function getHijriYear(int $year, int $nextYear = 0): int
+    {
+        $formatter = $this->getIslamicFormatter();
+        $formatter->setPattern('yyyy');
+
+        /** @var CarbonImmutable $dateTime */
+        $dateTime = CarbonImmutable::createFromFormat("d/m/Y", '01/01/' . ($year + $nextYear));
+
+        $hijriYear = $formatter->format($dateTime);
+
+        return (int) $hijriYear;
+    }
+}

--- a/src/Countries/Singapore.php
+++ b/src/Countries/Singapore.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+use DateTime;
+use Solaris\MoonPhase;
+use Spatie\Holidays\Calendars\ChineseCalendar;
+use Spatie\Holidays\Calendars\IndianCalendar;
+use Spatie\Holidays\Calendars\IslamicCalendar;
+
+class Singapore extends Country
+{
+    use ChineseCalendar;
+    use IslamicCalendar;
+    use IndianCalendar;
+
+    protected string $timezone = "Asia/Singapore";
+
+    public function countryCode(): string
+    {
+        return 'sg';
+    }
+
+    protected function allHolidays(int $year): array
+    {
+        return array_merge(
+            $this->fixedHolidays($year),
+            $this->variableHolidays($year)
+        );
+    }
+
+    /** @return array<string, string|CarbonImmutable> */
+    protected function fixedHolidays(int $year): array
+    {
+        #Fixed holidays in Singapore
+        return array_merge(
+            $this->replaceHolidayFallsOnSunday("New Year's Day", $year, "01-01"),
+            $this->replaceHolidayFallsOnSunday("Labor Day", $year, "05-01"),
+            $this->replaceHolidayFallsOnSunday("National Day", $year, "08-09"),
+            $this->replaceHolidayFallsOnSunday("Christmas Day", $year, "12-25"),
+        );
+    }
+
+    /** @return array<string, string|CarbonImmutable> */
+    protected function variableHolidays(int $year): array
+    {
+
+        $easter = $this->easter($year);
+
+        $this->setChineseCalendarTimezone($this->timezone);
+        $this->setIslamicCalendarTimezone($this->timezone);
+
+        return array_merge(
+            $this->replaceHolidayFallsOnSunday("Chinese New Year Day 1", $year, $this->chineseToGregorianDate("01-01", $year)->format("m-d"), 2), // In singapore if consecutive holiday falls on sunday and monday, sunday holiday will moved to tuesday
+            $this->replaceHolidayFallsOnSunday("Chinese New Year Day 2", $year, $this->chineseToGregorianDate("01-02", $year)->format("m-d")),
+            $this->replaceHolidayFallsOnSunday("Hari Raya Pausa", $year, $this->islamicToGregorianDate("01-10", $year)->format("m-d")),
+            $this->replaceHolidayFallsOnSunday("Vesak Day", $year, $this->chineseToGregorianDate("04-15", $year)->format("m-d")),
+            $this->replaceHolidayFallsOnSunday("Hari Raya Haji", $year, $this->islamicToGregorianDate("10-12", $year)->format("m-d")),
+            $this->getDeepavali($year),
+            [
+                'Good Friday' => $easter->subDays(2),
+            ]
+        );
+    }
+
+    /**
+     * @param string $holidayName
+     * @param int $year
+     * @param string $input
+     * @param int $moveDays | For consecutive holidays like Chinese New Year. If holiday falls on sunday and monday, sunday holiday will move to tuesday
+     * 
+     * @return array<string, string|CarbonImmutable> 
+     */
+    protected function replaceHolidayFallsOnSunday(string $holidayName, int $year, string $input, int $moveDays = 1): array
+    {
+        /** @var CarbonImmutable $dateTime */
+        $dateTime = CarbonImmutable::createFromFormat("Y-m-d", $year . "-" . $input);
+
+        $replacementDay = [];
+        $holiday = [$holidayName => $dateTime->format("m-d")];
+        if ($dateTime->isSunday()) {
+            $dateTime = $dateTime->addDays($moveDays);
+            $replacementDay = ["$holidayName (Replacement)" => $dateTime->format("m-d")];
+        }
+
+        return array_merge(
+            $holiday,
+            $replacementDay
+        );
+    }
+
+    /** @return array<string, string|CarbonImmutable> */
+    protected function getDeepavali(int $year): array
+    {
+        // Kartik month
+        $date = "08-01";
+
+        $deepavaliDateBasedFromIndianCalendar = $this->indianToGregorianDate($date, $year)->format("m-d");
+
+        $regularHoliday = $this->getPhaseNextNewMoon($year . "-" . $deepavaliDateBasedFromIndianCalendar);
+        return $this->replaceHolidayFallsOnSunday("Deepavali", $year, $regularHoliday);
+    }
+
+    protected function getPhaseNextNewMoon(string $input): string
+    {
+        $moonPhase = new MoonPhase(new DateTime($input));
+        $phaseNextNewMoon = CarbonImmutable::createFromTimestamp((int) $moonPhase->getPhaseNextNewMoon())->subDay()->format("m-d");
+
+        return $phaseNextNewMoon;
+    }
+}

--- a/tests/.pest/snapshots/Countries/SingaporeTest/it_can_calculate_singapore_2022_holidays.snap
+++ b/tests/.pest/snapshots/Countries/SingaporeTest/it_can_calculate_singapore_2022_holidays.snap
@@ -1,0 +1,62 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2022-01-01"
+    },
+    {
+        "name": "Chinese New Year Day 1",
+        "date": "2022-02-01"
+    },
+    {
+        "name": "Chinese New Year Day 2",
+        "date": "2022-02-02"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2022-04-15"
+    },
+    {
+        "name": "Labor Day",
+        "date": "2022-05-01"
+    },
+    {
+        "name": "Labor Day (Replacement)",
+        "date": "2022-05-02"
+    },
+    {
+        "name": "Hari Raya Pausa",
+        "date": "2022-05-03"
+    },
+    {
+        "name": "Vesak Day",
+        "date": "2022-05-15"
+    },
+    {
+        "name": "Vesak Day (Replacement)",
+        "date": "2022-05-16"
+    },
+    {
+        "name": "Hari Raya Haji",
+        "date": "2022-07-10"
+    },
+    {
+        "name": "Hari Raya Haji (Replacement)",
+        "date": "2022-07-11"
+    },
+    {
+        "name": "National Day",
+        "date": "2022-08-09"
+    },
+    {
+        "name": "Deepavali",
+        "date": "2022-10-24"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2022-12-25"
+    },
+    {
+        "name": "Christmas Day (Replacement)",
+        "date": "2022-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/SingaporeTest/it_can_calculate_singapore_2023_holidays.snap
+++ b/tests/.pest/snapshots/Countries/SingaporeTest/it_can_calculate_singapore_2023_holidays.snap
@@ -1,0 +1,58 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2023-01-01"
+    },
+    {
+        "name": "New Year's Day (Replacement)",
+        "date": "2023-01-02"
+    },
+    {
+        "name": "Chinese New Year Day 1",
+        "date": "2023-01-22"
+    },
+    {
+        "name": "Chinese New Year Day 2",
+        "date": "2023-01-23"
+    },
+    {
+        "name": "Chinese New Year Day 1 (Replacement)",
+        "date": "2023-01-24"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2023-04-07"
+    },
+    {
+        "name": "Hari Raya Pausa",
+        "date": "2023-04-22"
+    },
+    {
+        "name": "Labor Day",
+        "date": "2023-05-01"
+    },
+    {
+        "name": "Vesak Day",
+        "date": "2023-06-02"
+    },
+    {
+        "name": "Hari Raya Haji",
+        "date": "2023-06-29"
+    },
+    {
+        "name": "National Day",
+        "date": "2023-08-09"
+    },
+    {
+        "name": "Deepavali",
+        "date": "2023-11-12"
+    },
+    {
+        "name": "Deepavali (Replacement)",
+        "date": "2023-11-13"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2023-12-25"
+    }
+]

--- a/tests/.pest/snapshots/Countries/SingaporeTest/it_can_calculate_singapore_2024_holidays.snap
+++ b/tests/.pest/snapshots/Countries/SingaporeTest/it_can_calculate_singapore_2024_holidays.snap
@@ -1,0 +1,50 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Chinese New Year Day 1",
+        "date": "2024-02-10"
+    },
+    {
+        "name": "Chinese New Year Day 2",
+        "date": "2024-02-11"
+    },
+    {
+        "name": "Chinese New Year Day 2 (Replacement)",
+        "date": "2024-02-12"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2024-03-29"
+    },
+    {
+        "name": "Hari Raya Pausa",
+        "date": "2024-04-10"
+    },
+    {
+        "name": "Labor Day",
+        "date": "2024-05-01"
+    },
+    {
+        "name": "Vesak Day",
+        "date": "2024-05-22"
+    },
+    {
+        "name": "Hari Raya Haji",
+        "date": "2024-06-17"
+    },
+    {
+        "name": "National Day",
+        "date": "2024-08-09"
+    },
+    {
+        "name": "Deepavali",
+        "date": "2024-10-31"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2024-12-25"
+    }
+]

--- a/tests/Countries/SingaporeTest.php
+++ b/tests/Countries/SingaporeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spatie\Holidays\Tests\Countries;
+
+use Carbon\CarbonImmutable;
+use Spatie\Holidays\Holidays;
+
+it('can calculate singapore 2024 holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2024-01-01');
+
+    $holidays = Holidays::for(country: 'sg')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+
+});
+
+it('can calculate singapore 2023 holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2023-01-01');
+
+    $holidays = Holidays::for(country: 'sg')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+
+});
+
+it('can calculate singapore 2022 holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2022-01-01');
+
+    $holidays = Holidays::for(country: 'sg')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+
+});


### PR DESCRIPTION
### Singapore Holidays

- New Year's Day
- Chinese New Year
- Good Friday
- Hari Raya Puasa
- Labour Day
- Vesak Day
- Hari Raya Haji
- National Day
- Deepavali
- Christmas Day

## Changes
- Replacement for `Holidays`. If falls on `Sunday`, `Monday `will be the replacement. For `Chinese New Year`, if the Day is Sunday and Monday then the `Tuesday` will be the replacement for `Sunday`.
- Used `IntlDateFormatter` for accurate calendar calculations
- Added `Chinese Calendar` to get the Chinese New Year and Vesak Day dates
- Added `Islamic Calendar` to get the Hari Raya Puasa and Hari Raya Haji dates
- Added `Indian Calendar` to get the Kartik month which is 8th month of the Indian Calendar and 10th month of the Gregorian Calendar.
- Used the `solaris/php-moon-phase` for accurate computation of moon phases. Especially for `Deepavali` holiday, as this holiday is based on moon appearance

## Additional Notes

1. The `solaris/php-moon-phase` extension is required for this addition. It is referenced in the `composer.json` file.

## References:
Singapore's Ministry of Manpower to reference the Holidays in Singapore
[MOM Gov Public Holiday](https://www.mom.gov.sg/employment-practices/public-holidays)

Deepavali date is based on the appearance of the moon.
[Deepavali is subject to change](https://www.mom.gov.sg/faq/public-holidays/will-deepavali-date-be-subject-to-change)

[Chinese Calendar](https://en.wikipedia.org/wiki/Chinese_calendar)
[Islamic Calendar](https://www.muis.gov.sg/Media/Islamic-Calendar)
[Indian Calendar](https://en.wikipedia.org/wiki/Hindu_calendar)