### PR TITLE
Add Norway Holidays

### DIFF
--- a/src/Countries/Norway.php
+++ b/src/Countries/Norway.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+
+class Norway extends Country
+{
+    public function countryCode(): string
+    {
+        return 'no';
+    }
+
+    protected function allHolidays(int $year): array
+    {
+        return array_merge([
+            'Første nyttårsdag' => '01-01',
+            'Arbeidernes dag' => '05-01',
+            'Grunnlovsdag' => '05-17',
+            'Første juledag' => '12-25',
+            'Andre juledag' => '12-26',
+        ], $this->variableHolidays($year));
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function variableHolidays(int $year): array
+    {
+        $easter = CarbonImmutable::createFromTimestamp(easter_date($year))
+            ->setTimezone('Europe/Oslo');
+
+        $holidays = [
+            'Skjærtorsdag' => $easter->subDays(3),
+            'Langfredag' => $easter->subDays(2),
+            'Første påskedag' => $easter,
+            'Andre påskedag,' => $easter->addDay(),
+            'Kristi Himmelfartsdag' => $easter->addDays(39),
+            'Første pinsedag' => $easter->addDays(49),
+            'Andre pinsedag' => $easter->addDays(50),
+        ];
+
+        return $holidays;
+    }
+}

--- a/tests/.pest/snapshots/Countries/NorwayTest/it_can_calculate_norwegian_holidays.snap
+++ b/tests/.pest/snapshots/Countries/NorwayTest/it_can_calculate_norwegian_holidays.snap
@@ -1,0 +1,50 @@
+[
+    {
+        "name": "F\u00f8rste nytt\u00e5rsdag",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Skj\u00e6rtorsdag",
+        "date": "2024-03-28"
+    },
+    {
+        "name": "Langfredag",
+        "date": "2024-03-29"
+    },
+    {
+        "name": "F\u00f8rste p\u00e5skedag",
+        "date": "2024-03-31"
+    },
+    {
+        "name": "Andre p\u00e5skedag,",
+        "date": "2024-04-01"
+    },
+    {
+        "name": "Arbeidernes dag",
+        "date": "2024-05-01"
+    },
+    {
+        "name": "Kristi Himmelfartsdag",
+        "date": "2024-05-09"
+    },
+    {
+        "name": "Grunnlovsdag",
+        "date": "2024-05-17"
+    },
+    {
+        "name": "F\u00f8rste pinsedag",
+        "date": "2024-05-19"
+    },
+    {
+        "name": "Andre pinsedag",
+        "date": "2024-05-20"
+    },
+    {
+        "name": "F\u00f8rste juledag",
+        "date": "2024-12-25"
+    },
+    {
+        "name": "Andre juledag",
+        "date": "2024-12-26"
+    }
+]

--- a/tests/Countries/NorwayTest.php
+++ b/tests/Countries/NorwayTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Holidays\Tests\Countries;
+
+use Carbon\CarbonImmutable;
+use Spatie\Holidays\Holidays;
+
+it('can calculate norwegian holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2024-01-01');
+
+    $holidays = Holidays::for(country: 'no')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+});


### PR DESCRIPTION
Added Norwegian holidays.
Reference: https://www.timeanddate.no/merkedag/norge/2024