### PR TITLE
Added Kenyan Holidays

### DIFF
--- a/src/Countries/Kenya.php
+++ b/src/Countries/Kenya.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Date 19/01/2024
+ *
+ * @author   Simon Siva <simonsiva13@gmail.com>
+ */
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+
+class Kenya extends Country
+{
+    
+    public function countryCode(): string
+    {
+        return 'ke';
+    }
+    
+    /**
+     * @inheritDoc
+     */
+    protected function allHolidays(int $year): array
+    {
+        return array_merge([
+            'New Year' => '01-01',
+            'Labour Day' => '05-01',
+            'Madaraka Day' => '06-01',
+            'Huduma/Utamaduni Day' => '10-10',
+            'Mashujaa Day' => '10-20',
+            'Jamhuri Day' => '12-12',
+            'Christmas Day' => '12-25',
+            'Boxing Day' => '12-26',
+        ], $this->variableHolidays($year));
+    }
+    
+    /**
+     * @param int $year
+     *
+     * @return array<string, CarbonImmutable>
+     */
+    private function variableHolidays(int $year): array
+    {
+        $easter = CarbonImmutable::createFromTimestamp(easter_date($year))->setTimezone('Africa/Nairobi');
+        return [
+            "Good Friday" => $easter->subDays(2),
+            "Easter Monday" => $easter->addDay(),
+        ];
+    }
+}

--- a/tests/.pest/snapshots/Countries/KenyaTest/it_can_calculate_kenyan_holidays_2024.snap
+++ b/tests/.pest/snapshots/Countries/KenyaTest/it_can_calculate_kenyan_holidays_2024.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2024-03-29"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2024-04-01"
+    },
+    {
+        "name": "Labour Day",
+        "date": "2024-05-01"
+    },
+    {
+        "name": "Madaraka Day",
+        "date": "2024-06-01"
+    },
+    {
+        "name": "Huduma\/Utamaduni Day",
+        "date": "2024-10-10"
+    },
+    {
+        "name": "Mashujaa Day",
+        "date": "2024-10-20"
+    },
+    {
+        "name": "Jamhuri Day",
+        "date": "2024-12-12"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2024-12-25"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2024-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/KenyaTest/it_can_calculate_kenyan_holidays_2026.snap
+++ b/tests/.pest/snapshots/Countries/KenyaTest/it_can_calculate_kenyan_holidays_2026.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year",
+        "date": "2026-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2026-04-03"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2026-04-06"
+    },
+    {
+        "name": "Labour Day",
+        "date": "2026-05-01"
+    },
+    {
+        "name": "Madaraka Day",
+        "date": "2026-06-01"
+    },
+    {
+        "name": "Huduma\/Utamaduni Day",
+        "date": "2026-10-10"
+    },
+    {
+        "name": "Mashujaa Day",
+        "date": "2026-10-20"
+    },
+    {
+        "name": "Jamhuri Day",
+        "date": "2026-12-12"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2026-12-25"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2026-12-26"
+    }
+]

--- a/tests/Countries/KenyaTest.php
+++ b/tests/Countries/KenyaTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\Holidays\Tests\Countries;
+
+use Carbon\CarbonImmutable;
+use Spatie\Holidays\Countries\Kenya;
+use Spatie\Holidays\Holidays;
+
+it('can calculate kenyan holidays 2024', function () {
+    CarbonImmutable::setTestNowAndTimezone('2024-10-10');
+    $holidays = Holidays::for(Kenya::make())->get();
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate kenyan holidays 2026', function () {
+    CarbonImmutable::setTestNowAndTimezone('2026-06-01');
+    $holidays = Holidays::for(Kenya::make())->get();
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+});


### PR DESCRIPTION
Added Kenyan Holidays
- New Years Day ............. 1 January.
- Good Friday .................. March or April.
- Easter Monday .............. March or April.
- Labour Day .................... 1st May.
- Madaraka Day ............... 1st June.
- Moi Day ......................... 10th October.
- Kenyatta Day ................. 20th October.
- Jamhuri/Independence Day ........ 12th December.
- Christmas Day ............... 25th December.
- Boxing Day .................... 26th December.

Leaving out the following for the stated reasons
- Idd-ul-Azha .................... Date depending upon the appearance of the moon.
- Idd-ul-Fitr ....................... Date depending upon the appearance of the moon.
- Diwali ............................. Date to be determined in accordance with the Hindu Calendar.