### PR TITLE
Support for Taiwan holidays

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "nesbot/carbon": "^2.72.1",
-        "ext-calendar": "*"
+        "ext-intl": "*",
+        "nesbot/carbon": "^2.72.1"
     },
     "require-dev": {
         "laravel/prompts": "^0.1.15",

--- a/src/Countries/Taiwan.php
+++ b/src/Countries/Taiwan.php
@@ -18,10 +18,10 @@ class Taiwan extends Country
     protected function allHolidays(int $year): array
     {
         return array_merge([
-            'New Year\'s Day' => '01-01',
-            'Peace Memorial Day' => '02-28',
-            'Children\'s Day' => '04-04',
-            'National Day' => '10-10',
+            '元旦' => '01-01',
+            '228和平紀念日' => '02-28',
+            '兒童節' => '04-04',
+            '雙十國慶' => '10-10',
         ], $this->variableHolidays($year));
     }
 
@@ -29,11 +29,11 @@ class Taiwan extends Country
     protected function variableHolidays(int $year): array
     {
         return array_filter(array_map(fn ($date) => $this->lunarCalendar($date, $year), [
-            'First day of the Lunar New Year' => '01-01',
-            'Second day of the Lunar New Year' => '01-02',
-            'Third day of the Lunar New Year' => '01-03',
-            'Dragon Boat Festival' => '05-05',
-            'Moon Festival' => '08-15',
+            '農曆春節-正月初一' => '01-01',
+            '農曆春節-正月初二' => '01-02',
+            '農曆春節-正月初三' => '01-03',
+            '端午節' => '05-05',
+            '中秋節' => '08-15',
         ]));
     }
 

--- a/src/Countries/Taiwan.php
+++ b/src/Countries/Taiwan.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use DateTimeZone;
+use IntlDateFormatter;
+
+class Taiwan extends Country
+{
+    protected string $timezone = 'Asia/Taipei';
+
+    public function countryCode(): string
+    {
+        return 'tw';
+    }
+
+    protected function allHolidays(int $year): array
+    {
+        return array_merge([
+            'New Year\'s Day' => '01-01',
+            'Peace Memorial Day' => '02-28',
+            'Children\'s Day' => '04-04',
+            'National Day' => '10-10',
+        ], $this->variableHolidays($year));
+    }
+
+    /** @return array<string, string> */
+    protected function variableHolidays(int $year): array
+    {
+        return [
+            'First day of the Lunar New Year' => $this->lunarCalendar('01-01', $year),
+            'Second day of the Lunar New Year' => $this->lunarCalendar('01-02', $year),
+            'Third day of the Lunar New Year' => $this->lunarCalendar('01-03', $year),
+            'Dragon Boat Festival' => $this->lunarCalendar('05-05', $year),
+            'Moon Festival' => $this->lunarCalendar('08-15', $year),
+        ];
+    }
+
+    protected function lunarCalendar(string $input, int $year): string
+    {
+        $formatter = new IntlDateFormatter(
+            locale: 'zh-TW@calendar=chinese',
+            dateType: IntlDateFormatter::SHORT,
+            timeType: IntlDateFormatter::NONE,
+            timezone: $this->timezone,
+            calendar: IntlDateFormatter::TRADITIONAL
+        );
+
+        return date_create()
+            ->setTimeStamp($formatter->parse($year . '-' . $input))
+            ->setTimezone(new DateTimeZone($this->timezone))
+            ->format('m-d');
+    }
+}

--- a/src/Countries/Taiwan.php
+++ b/src/Countries/Taiwan.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Holidays\Countries;
 
+use DateTime;
 use DateTimeZone;
 use IntlDateFormatter;
 
@@ -27,16 +28,16 @@ class Taiwan extends Country
     /** @return array<string, string> */
     protected function variableHolidays(int $year): array
     {
-        return [
-            'First day of the Lunar New Year' => $this->lunarCalendar('01-01', $year),
-            'Second day of the Lunar New Year' => $this->lunarCalendar('01-02', $year),
-            'Third day of the Lunar New Year' => $this->lunarCalendar('01-03', $year),
-            'Dragon Boat Festival' => $this->lunarCalendar('05-05', $year),
-            'Moon Festival' => $this->lunarCalendar('08-15', $year),
-        ];
+        return array_filter([
+            'First day of the Lunar New Year' => '01-01',
+            'Second day of the Lunar New Year' => '01-02',
+            'Third day of the Lunar New Year' => '01-03',
+            'Dragon Boat Festival' => '05-05',
+            'Moon Festival' => '08-15',
+        ], fn ($date) => $this->lunarCalendar($date, $year) !== null);
     }
 
-    protected function lunarCalendar(string $input, int $year): string
+    protected function lunarCalendar(string $input, int $year): ?string
     {
         $formatter = new IntlDateFormatter(
             locale: 'zh-TW@calendar=chinese',
@@ -46,9 +47,17 @@ class Taiwan extends Country
             calendar: IntlDateFormatter::TRADITIONAL
         );
 
-        return date_create()
-            ->setTimeStamp($formatter->parse($year . '-' . $input))
-            ->setTimezone(new DateTimeZone($this->timezone))
-            ->format('m-d');
+        $lunarDateStr = $year . '-' . $input;
+        $parsedTimestamp = $formatter->parse($lunarDateStr);
+
+        if ($parsedTimestamp === false) {
+            return null;
+        }
+
+        $dateTime = new DateTime;
+        $dateTime->setTimestamp($parsedTimestamp);
+        $dateTime->setTimezone(new DateTimeZone($this->timezone));
+
+        return $dateTime->format('m-d');
     }
 }

--- a/src/Countries/Taiwan.php
+++ b/src/Countries/Taiwan.php
@@ -28,13 +28,19 @@ class Taiwan extends Country
     /** @return array<string, string> */
     protected function variableHolidays(int $year): array
     {
-        return array_filter([
+        $holidays = [
             'First day of the Lunar New Year' => '01-01',
             'Second day of the Lunar New Year' => '01-02',
             'Third day of the Lunar New Year' => '01-03',
             'Dragon Boat Festival' => '05-05',
             'Moon Festival' => '08-15',
-        ], fn ($date) => $this->lunarCalendar($date, $year) !== null);
+        ];
+
+        $convertedHolidays = array_map(function ($date) use ($year) {
+            return $this->lunarCalendar($date, $year);
+        }, $holidays);
+
+        return array_filter($convertedHolidays);
     }
 
     protected function lunarCalendar(string $input, int $year): ?string

--- a/src/Countries/Taiwan.php
+++ b/src/Countries/Taiwan.php
@@ -28,19 +28,13 @@ class Taiwan extends Country
     /** @return array<string, string> */
     protected function variableHolidays(int $year): array
     {
-        $holidays = [
+        return array_filter(array_map(fn ($date) => $this->lunarCalendar($date, $year), [
             'First day of the Lunar New Year' => '01-01',
             'Second day of the Lunar New Year' => '01-02',
             'Third day of the Lunar New Year' => '01-03',
             'Dragon Boat Festival' => '05-05',
             'Moon Festival' => '08-15',
-        ];
-
-        $convertedHolidays = array_map(function ($date) use ($year) {
-            return $this->lunarCalendar($date, $year);
-        }, $holidays);
-
-        return array_filter($convertedHolidays);
+        ]));
     }
 
     protected function lunarCalendar(string $input, int $year): ?string

--- a/tests/.pest/snapshots/Countries/TaiwanTest/it_can_calculate_taiwan_holidays.snap
+++ b/tests/.pest/snapshots/Countries/TaiwanTest/it_can_calculate_taiwan_holidays.snap
@@ -1,38 +1,38 @@
 [
     {
-        "name": "New Year's Day",
+        "name": "\u5143\u65e6",
         "date": "2024-01-01"
     },
     {
-        "name": "First day of the Lunar New Year",
+        "name": "\u8fb2\u66c6\u6625\u7bc0-\u6b63\u6708\u521d\u4e00",
         "date": "2024-02-10"
     },
     {
-        "name": "Second day of the Lunar New Year",
+        "name": "\u8fb2\u66c6\u6625\u7bc0-\u6b63\u6708\u521d\u4e8c",
         "date": "2024-02-11"
     },
     {
-        "name": "Third day of the Lunar New Year",
+        "name": "\u8fb2\u66c6\u6625\u7bc0-\u6b63\u6708\u521d\u4e09",
         "date": "2024-02-12"
     },
     {
-        "name": "Peace Memorial Day",
+        "name": "228\u548c\u5e73\u7d00\u5ff5\u65e5",
         "date": "2024-02-28"
     },
     {
-        "name": "Children's Day",
+        "name": "\u5152\u7ae5\u7bc0",
         "date": "2024-04-04"
     },
     {
-        "name": "Dragon Boat Festival",
+        "name": "\u7aef\u5348\u7bc0",
         "date": "2024-06-10"
     },
     {
-        "name": "Moon Festival",
+        "name": "\u4e2d\u79cb\u7bc0",
         "date": "2024-09-17"
     },
     {
-        "name": "National Day",
+        "name": "\u96d9\u5341\u570b\u6176",
         "date": "2024-10-10"
     }
 ]

--- a/tests/.pest/snapshots/Countries/TaiwanTest/it_can_calculate_taiwan_holidays.snap
+++ b/tests/.pest/snapshots/Countries/TaiwanTest/it_can_calculate_taiwan_holidays.snap
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "First day of the Lunar New Year",
+        "date": "2024-02-10"
+    },
+    {
+        "name": "Second day of the Lunar New Year",
+        "date": "2024-02-11"
+    },
+    {
+        "name": "Third day of the Lunar New Year",
+        "date": "2024-02-12"
+    },
+    {
+        "name": "Peace Memorial Day",
+        "date": "2024-02-28"
+    },
+    {
+        "name": "Children's Day",
+        "date": "2024-04-04"
+    },
+    {
+        "name": "Dragon Boat Festival",
+        "date": "2024-06-10"
+    },
+    {
+        "name": "Moon Festival",
+        "date": "2024-09-17"
+    },
+    {
+        "name": "National Day",
+        "date": "2024-10-10"
+    }
+]

--- a/tests/Countries/TaiwanTest.php
+++ b/tests/Countries/TaiwanTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Holidays\Tests\Countries;
+
+use Carbon\CarbonImmutable;
+use Spatie\Holidays\Holidays;
+
+it('can calculate taiwan holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2024-01-01');
+
+    $holidays = Holidays::for(country: 'tw')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+
+});


### PR DESCRIPTION
## Contributing a new country ?

- [x]  Have you checked to ensure there aren't other open [Pull Requests](https://github.com/spatie/holidays/pulls) for the same country?

1. Create a new class in the Countries directory. It should extend the Country class.
2. Add a test for the new country in the tests directory.
3. Run the tests so a snapshot gets created.
4. Verify the result in the newly created snapshot is correct.

## Changes

1. Added a new `Taiwan` class in the `Holidays` directory.
2. Implemented holiday calculations specific to Taiwan, including both fixed-date holidays and those that require lunar calendar calculations.
3. Used the `ext-intl` extension and `IntlDateFormatter` for accurate lunar calendar calculations, ensuring that holidays based on the lunar calendar are correctly determined.

## Additional Notes

1. The `ext-intl` extension is required for this addition. It is referenced in the `composer.json` file.

## References

1. https://publicholidays.tw/2024-dates/
