### PR TITLE
Albanian National Holidays

### DIFF
--- a/src/Countries/Albania.php
+++ b/src/Countries/Albania.php
@@ -26,7 +26,7 @@ class Albania extends Country
         ], $this->variableHolidays($year));
     }
 
-    /** @return array<string, CarbonImmutable> */
+    /** @return array<string, CarbonImmutable|string> */
     protected function variableHolidays(int $year): array
     {
         return [
@@ -40,13 +40,13 @@ class Albania extends Country
     /**
      * 
      */
-    private function getEidAlFitrHoliday(int $year): CarbonImmutable
+    private function getEidAlFitrHoliday(int $year): string
     {
         /**
          * Provided until 2034 by qppstudio.net.
          * https://www.qppstudio.net/global-holidays-observances/eid-al-fitr-end-of-ramadan.htm
          */
-        $date = match ($year) {
+        return match ($year) {
             2024 => '04-10',
             2025 => '03-30',
             2026 => '03-20',
@@ -60,19 +60,16 @@ class Albania extends Country
             2034 => '12-12',
             default => '01-01' // Temporary placeholder; requires ongoing maintenance.
         };
-
-        return CarbonImmutable::createFromFormat('Y-m-d', "$year-$date")
-            ->startOfDay();
     }
 
-    private function getEidAlAdhaHoliday(int $year): CarbonImmutable
+    private function getEidAlAdhaHoliday(int $year): string
     {
         /**
          * Tentative dates.
          * Provided until 2034 by timeanddate.com.
          * https://www.timeanddate.com/holidays/us/eid-al-adha
          */
-        $date = match ($year) {
+        return match ($year) {
             2024 => '06-17',
             2025 => '06-07',
             2026 => '05-27',
@@ -86,9 +83,6 @@ class Albania extends Country
             2034 => '03-01',
             default => '01-01' // Temporary placeholder; requires ongoing maintenance.
         };
-
-        return CarbonImmutable::createFromFormat('Y-m-d', "$year-$date")
-            ->startOfDay();
     }
 
 }

--- a/src/Countries/Albania.php
+++ b/src/Countries/Albania.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+
+class Albania extends Country
+{
+    public function countryCode(): string
+    {
+        return 'al';
+    }
+
+    protected function allHolidays(int $year): array
+    {
+        return array_merge([
+            'Viti i Ri' => '01-01',
+            'Dita e Verës' => '03-14',
+            'Dita e Sulltan Nevruzit' => '03-22',
+            'Dita Ndërkombëtare e Punëtorëve' => '05-01',
+            'Dita e Shenjtërimit të Shenjt Terezës' => '09-05',
+            'Dita e Pavarësisë' => '11-28',
+            'Dita e Çlirimit' => '11-29',
+            'Dita Kombëtare e Rinisë' => '12-08',
+            'Krishtlindjet' => '12-25',
+        ], $this->variableHolidays($year));
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function variableHolidays(int $year): array
+    {
+        return [
+            'E diela e Pashkëve Katolike' => $this->easter($year),
+            'E diela e Pashkëve Ortodokse' => $this->orthodoxEaster($year),
+            'Dita e Bajramit të Madh' => $this->getEidAlFitrHoliday($year),
+            'Dita e Kurban Bajramit' => $this->getEidAlAdhaHoliday($year),
+        ];
+    }
+
+    /**
+     * 
+     */
+    private function getEidAlFitrHoliday(int $year): CarbonImmutable
+    {
+        /**
+         * Provided until 2034 by qppstudio.net.
+         * https://www.qppstudio.net/global-holidays-observances/eid-al-fitr-end-of-ramadan.htm
+         */
+        $date = match ($year) {
+            2024 => '04-10',
+            2025 => '03-30',
+            2026 => '03-20',
+            2027 => '03-09',
+            2028 => '02-26',
+            2029 => '02-14',
+            2030 => '02-04',
+            2031 => '01-24',
+            2032 => '01-14',
+            2033 => '01-02',
+            2034 => '12-12',
+            default => '01-01' // Temporary placeholder; requires ongoing maintenance.
+        };
+
+        return CarbonImmutable::createFromFormat('Y-m-d', "$year-$date")
+            ->startOfDay();
+    }
+
+    private function getEidAlAdhaHoliday(int $year): CarbonImmutable
+    {
+        /**
+         * Tentative dates.
+         * Provided until 2034 by timeanddate.com.
+         * https://www.timeanddate.com/holidays/us/eid-al-adha
+         */
+        $date = match ($year) {
+            2024 => '06-17',
+            2025 => '06-07',
+            2026 => '05-27',
+            2027 => '05-17',
+            2028 => '05-05',
+            2029 => '04-24',
+            2030 => '04-14',
+            2031 => '04-03',
+            2032 => '03-22',
+            2033 => '03-12',
+            2034 => '03-01',
+            default => '01-01' // Temporary placeholder; requires ongoing maintenance.
+        };
+
+        return CarbonImmutable::createFromFormat('Y-m-d', "$year-$date")
+            ->startOfDay();
+    }
+
+}

--- a/src/Countries/Albania.php
+++ b/src/Countries/Albania.php
@@ -29,18 +29,18 @@ class Albania extends Country
     /** @return array<string, CarbonImmutable|string> */
     protected function variableHolidays(int $year): array
     {
-        return [
+        return array_filter([
             'E diela e Pashkëve Katolike' => $this->easter($year),
             'E diela e Pashkëve Ortodokse' => $this->orthodoxEaster($year),
             'Dita e Bajramit të Madh' => $this->getEidAlFitrHoliday($year),
             'Dita e Kurban Bajramit' => $this->getEidAlAdhaHoliday($year),
-        ];
+        ]);
     }
 
     /**
      * 
      */
-    private function getEidAlFitrHoliday(int $year): string
+    private function getEidAlFitrHoliday(int $year): ?string
     {
         /**
          * Provided until 2034 by qppstudio.net.
@@ -58,11 +58,11 @@ class Albania extends Country
             2032 => '01-14',
             2033 => '01-02',
             2034 => '12-12',
-            default => '01-01' // Temporary placeholder; requires ongoing maintenance.
+            default => null // Holiday is variable; requires ongoing maintenance.
         };
     }
 
-    private function getEidAlAdhaHoliday(int $year): string
+    private function getEidAlAdhaHoliday(int $year): ?string
     {
         /**
          * Tentative dates.
@@ -81,7 +81,7 @@ class Albania extends Country
             2032 => '03-22',
             2033 => '03-12',
             2034 => '03-01',
-            default => '01-01' // Temporary placeholder; requires ongoing maintenance.
+            default => null // Holiday is variable; requires ongoing maintenance.
         };
     }
 

--- a/src/Countries/Albania.php
+++ b/src/Countries/Albania.php
@@ -22,7 +22,7 @@ class Albania extends Country
             'Dita e Pavarësisë' => '11-28',
             'Dita e Çlirimit' => '11-29',
             'Dita Kombëtare e Rinisë' => '12-08',
-            'Krishtlindjet' => '12-25',
+            'Krishtlindja' => '12-25',
         ], $this->variableHolidays($year));
     }
 

--- a/src/lang/albania/de/holidays.json
+++ b/src/lang/albania/de/holidays.json
@@ -1,0 +1,15 @@
+{
+    "Viti i Ri": "Neujahr",
+    "Dita e Verës": "Sommertag",
+    "Dita e Sulltan Nevruzit": "Tag des Sultan Nevruz",
+    "Dita Ndërkombëtare e Punëtorëve": "Tag der Arbeit",
+    "Dita e Shenjtërimit të Shenjt Terezës": "Tag der Heiligsprechung der Heiligen Teresa",
+    "Dita e Pavarësisë": "Unabhängigkeitstag",
+    "Dita e Çlirimit": "Befreiungstag",
+    "Dita Kombëtare e Rinisë": "Nationaler Jugendtag",
+    "Krishtlindja": "Weihnachten",
+    "E diela e Pashkëve Katolike": "Katholischer Ostersonntag",
+    "E diela e Pashkëve Ortodokse": "Orthodoxer Ostersonntag",
+    "Dita e Bajramit të Madh": "Eid al-Fitr",
+    "Dita e Kurban Bajramit": "Eid al-Adha"
+}

--- a/src/lang/albania/en/holidays.json
+++ b/src/lang/albania/en/holidays.json
@@ -1,0 +1,15 @@
+{
+    "Viti i Ri": "New Year's Day",
+    "Dita e Verës": "Summer Day",
+    "Dita e Sulltan Nevruzit": "Sultan Nevruz Day",
+    "Dita Ndërkombëtare e Punëtorëve": "International Workers' Day",
+    "Dita e Shenjtërimit të Shenjt Terezës": "Saint Teresa Canonization Day",
+    "Dita e Pavarësisë": "Independence Day",
+    "Dita e Çlirimit": "Liberation Day",
+    "Dita Kombëtare e Rinisë": "National Youth Day",
+    "Krishtlindja": "Christmas",
+    "E diela e Pashkëve Katolike": "Catholic Easter Sunday",
+    "E diela e Pashkëve Ortodokse": "Orthodox Easter Sunday",
+    "Dita e Bajramit të Madh": "Eid al-Fitr",
+    "Dita e Kurban Bajramit": "Eid al-Adha"
+}

--- a/src/lang/albania/es/holidays.json
+++ b/src/lang/albania/es/holidays.json
@@ -1,0 +1,15 @@
+{
+    "Viti i Ri": "Año Nuevo",
+    "Dita e Verës": "Día del Verano",
+    "Dita e Sulltan Nevruzit": "Día del Sultan Nevruz",
+    "Dita Ndërkombëtare e Punëtorëve": "Día Internacional de los Trabajadores",
+    "Dita e Shenjtërimit të Shenjt Terezës": "Día de la Canonización de Santa Teresa",
+    "Dita e Pavarësisë": "Día de la Independencia",
+    "Dita e Çlirimit": "Día de la Liberación",
+    "Dita Kombëtare e Rinisë": "Día Nacional de la Juventud",
+    "Krishtlindja": "Navidad",
+    "E diela e Pashkëve Katolike": "Domingo de Pascua Católica",
+    "E diela e Pashkëve Ortodokse": "Domingo de Pascua Ortodoxa",
+    "Dita e Bajramit të Madh": "Eid al-Fitr",
+    "Dita e Kurban Bajramit": "Eid al-Adha"
+}

--- a/src/lang/albania/fr/holidays.json
+++ b/src/lang/albania/fr/holidays.json
@@ -1,0 +1,16 @@
+{
+    "Viti i Ri": "Jour de l'An",
+    "Dita e Verës": "Jour de l'Été",
+    "Dita e Sulltan Nevruzit": "Jour du Sultan Nevruz",
+    "Dita Ndërkombëtare e Punëtorëve": "Fête du Travail",
+    "Dita e Shenjtërimit të Shenjt Terezës": "Jour de la Canonisation de Sainte Teresa",
+    "Dita e Pavarësisë": "Jour de l'Indépendance",
+    "Dita e Çlirimit": "Jour de la Libération",
+    "Dita Kombëtare e Rinisë": "Journée nationale de la jeunesse",
+    "Krishtlindja": "Noël",
+    "E diela e Pashkëve Katolike": "Dimanche de Pâques catholique",
+    "E diela e Pashkëve Ortodokse": "Dimanche de Pâques orthodoxe",
+    "Dita e Bajramit të Madh": "Aïd al-Fitr",
+    "Dita e Kurban Bajramit": "Aïd al-Adha"
+}
+

--- a/src/lang/albania/gr/holidays.json
+++ b/src/lang/albania/gr/holidays.json
@@ -1,0 +1,15 @@
+{
+    "Viti i Ri": "Πρωτοχρονιά (Protochroniá)",
+    "Dita e Verës": "Ημέρα του Καλοκαιριού (Iméra tou Kalokairioú)",
+    "Dita e Sulltan Nevruzit": "Ημέρα του Σουλτάν Nevruz (Iméra tou Soúltan Nevruz)",
+    "Dita Ndërkombëtare e Punëtorëve": "Διεθνής Ημέρα των Εργαζομένων (Diethnís Iméra ton Ergazoménon)",
+    "Dita e Shenjtërimit të Shenjt Terezës": "Ημέρα Κανονισμού της Αγίας Τερέζας (Iméra Kanonismoú tis Agías Terézas)",
+    "Dita e Pavarësisë": "Ημέρα Ανεξαρτησίας (Iméra Anexartisías)",
+    "Dita e Çlirimit": "Ημέρα Απελευθέρωσης (Iméra Apelafthéroses)",
+    "Dita Kombëtare e Rinisë": "Εθνική Ημέρα της Νεολαίας (Ethnikí Iméra tis Neoléas)",
+    "Krishtlindja": "Χριστούγεννα (Christoúgenna)",
+    "E diela e Pashkëve Katolike": "Κυριακή του Καθολικού Πάσχα (Kyriakí tou Katholikoú Páscha)",
+    "E diela e Pashkëve Ortodokse": "Κυριακή του Ορθόδοξου Πάσχα (Kyriakí tou Orthódoksi Páscha)",
+    "Dita e Bajramit të Madh": "Ημέρα του Μεγάλου Βαϊράμ (Iméra tou Megálou Vaïrám)",
+    "Dita e Kurban Bajramit": "Ημέρα του Κουρμπάν Βαϊράμ (Iméra tou Kourbán Vaïrám)"
+}

--- a/src/lang/albania/it/holidays.json
+++ b/src/lang/albania/it/holidays.json
@@ -1,0 +1,15 @@
+{
+    "Viti i Ri": "Capodanno",
+    "Dita e Verës": "Giorno d'Estate",
+    "Dita e Sulltan Nevruzit": "Giorno del Sultano Nevruz",
+    "Dita Ndërkombëtare e Punëtorëve": "Festa dei Lavoratori",
+    "Dita e Shenjtërimit të Shenjt Terezës": "Giorno della Canonizzazione di Santa Teresa",
+    "Dita e Pavarësisë": "Giorno dell'Indipendenza",
+    "Dita e Çlirimit": "Giorno della Liberazione",
+    "Dita Kombëtare e Rinisë": "Giornata Nazionale della Gioventù",
+    "Krishtlindja": "Natale",
+    "E diela e Pashkëve Katolike": "Domenica di Pasqua Cattolica",
+    "E diela e Pashkëve Ortodokse": "Domenica di Pasqua Ortodossa",
+    "Dita e Bajramit të Madh": "Eid al-Fitr",
+    "Dita e Kurban Bajramit": "Eid al-Adha"
+}

--- a/src/lang/albania/pt/holidays.json
+++ b/src/lang/albania/pt/holidays.json
@@ -1,0 +1,15 @@
+{
+    "Viti i Ri": "Ano Novo",
+    "Dita e Verës": "Dia do Verão",
+    "Dita e Sulltan Nevruzit": "Dia do Sultão Nevruz",
+    "Dita Ndërkombëtare e Punëtorëve": "Dia Internacional dos Trabalhadores",
+    "Dita e Shenjtërimit të Shenjt Terezës": "Dia da Canonização de Santa Teresa",
+    "Dita e Pavarësisë": "Dia da Independência",
+    "Dita e Çlirimit": "Dia da Libertação",
+    "Dita Kombëtare e Rinisë": "Dia Nacional da Juventude",
+    "Krishtlindja": "Natal",
+    "E diela e Pashkëve Katolike": "Domingo de Páscoa Católico",
+    "E diela e Pashkëve Ortodokse": "Domingo de Páscoa Ortodoxo",
+    "Dita e Bajramit të Madh": "Eid al-Fitr",
+    "Dita e Kurban Bajramit": "Eid al-Adha"
+}

--- a/src/lang/albania/ru/holidays.json
+++ b/src/lang/albania/ru/holidays.json
@@ -1,0 +1,15 @@
+{
+    "Viti i Ri": "Новий рік",
+    "Dita e Verës": "День літа",
+    "Dita e Sulltan Nevruzit": "День Султана Невруза",
+    "Dita Ndërkombëtare e Punëtorëve": "Міжнародний день праці",
+    "Dita e Shenjtërimit të Shenjt Terezës": "День канонізації Святої Терези",
+    "Dita e Pavarësisë": "День Незалежності",
+    "Dita e Çlirimit": "День Визволення",
+    "Dita Kombëtare e Rinisë": "Національний день молоді",
+    "Krishtlindja": "Різдво",
+    "E diela e Pashkëve Katolike": "Католицька неділя Великодня",
+    "E diela e Pashkëve Ortodokse": "Православна неділя Великодня",
+    "Dita e Bajramit të Madh": "Байрам",
+    "Dita e Kurban Bajramit": "Курбан-байрам"
+}

--- a/src/lang/albania/tr/holidays.json
+++ b/src/lang/albania/tr/holidays.json
@@ -1,0 +1,15 @@
+{
+    "Viti i Ri": "Yılbaşı",
+    "Dita e Verës": "Yaz Günü",
+    "Dita e Sulltan Nevruzit": "Sultan Nevruz Günü",
+    "Dita Ndërkombëtare e Punëtorëve": "Uluslararası İşçi Günü",
+    "Dita e Shenjtërimit të Shenjt Terezës": "Azize Teresa'nın Kanonizasyon Günü",
+    "Dita e Pavarësisë": "Bağımsızlık Günü",
+    "Dita e Çlirimit": "Kurtuluş Günü",
+    "Dita Kombëtare e Rinisë": "Ulusal Gençlik Günü",
+    "Krishtlindja": "Noel",
+    "E diela e Pashkëve Katolike": "Katolik Paskalya Pazarı",
+    "E diela e Pashkëve Ortodokse": "Ortodoks Paskalya Pazarı",
+    "Dita e Bajramit të Madh": "Ramazan Bayramı",
+    "Dita e Kurban Bajramit": "Kurban Bayramı"
+}

--- a/tests/.pest/snapshots/Countries/AlbaniaTest/it_can_calculate_albanian_holidays.snap
+++ b/tests/.pest/snapshots/Countries/AlbaniaTest/it_can_calculate_albanian_holidays.snap
@@ -48,7 +48,7 @@
         "date": "2024-12-08"
     },
     {
-        "name": "Krishtlindjet",
+        "name": "Krishtlindja",
         "date": "2024-12-25"
     }
 ]

--- a/tests/.pest/snapshots/Countries/AlbaniaTest/it_can_calculate_albanian_holidays.snap
+++ b/tests/.pest/snapshots/Countries/AlbaniaTest/it_can_calculate_albanian_holidays.snap
@@ -1,0 +1,54 @@
+[
+    {
+        "name": "Viti i Ri",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Dita e Ver\u00ebs",
+        "date": "2024-03-14"
+    },
+    {
+        "name": "Dita e Sulltan Nevruzit",
+        "date": "2024-03-22"
+    },
+    {
+        "name": "E diela e Pashk\u00ebve Katolike",
+        "date": "2024-03-31"
+    },
+    {
+        "name": "Dita e Bajramit t\u00eb Madh",
+        "date": "2024-04-10"
+    },
+    {
+        "name": "Dita Nd\u00ebrkomb\u00ebtare e Pun\u00ebtor\u00ebve",
+        "date": "2024-05-01"
+    },
+    {
+        "name": "E diela e Pashk\u00ebve Ortodokse",
+        "date": "2024-05-05"
+    },
+    {
+        "name": "Dita e Kurban Bajramit",
+        "date": "2024-06-17"
+    },
+    {
+        "name": "Dita e Shenjt\u00ebrimit t\u00eb Shenjt Terez\u00ebs",
+        "date": "2024-09-05"
+    },
+    {
+        "name": "Dita e Pavar\u00ebsis\u00eb",
+        "date": "2024-11-28"
+    },
+    {
+        "name": "Dita e \u00c7lirimit",
+        "date": "2024-11-29"
+    },
+    {
+        "name": "Dita Komb\u00ebtare e Rinis\u00eb",
+        "date": "2024-12-08"
+    },
+    {
+        "name": "Krishtlindjet",
+        "date": "2024-12-25"
+    }
+]

--- a/tests/Countries/AlbaniaTest.php
+++ b/tests/Countries/AlbaniaTest.php
@@ -121,4 +121,3 @@ describe('national holidays with standard dates', function() {
         expect($holidayName)->toBe('Krishtlindjet');
     });
  });
- 

--- a/tests/Countries/AlbaniaTest.php
+++ b/tests/Countries/AlbaniaTest.php
@@ -121,3 +121,4 @@ describe('national holidays with standard dates', function() {
         expect($holidayName)->toBe('Krishtlindjet');
     });
  });
+ 

--- a/tests/Countries/AlbaniaTest.php
+++ b/tests/Countries/AlbaniaTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Holidays\Tests\Countries;
+
+use Carbon\CarbonImmutable;
+use Spatie\Holidays\Holidays;
+
+it('can calculate albanian holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2024-01-01');
+
+    $holidays = Holidays::for(country: 'al')->get();
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+});

--- a/tests/Countries/AlbaniaTest.php
+++ b/tests/Countries/AlbaniaTest.php
@@ -15,3 +15,109 @@ it('can calculate albanian holidays', function () {
 
     expect(formatDates($holidays))->toMatchSnapshot();
 });
+
+
+it('does not return a holiday falsely', function() use ($holiday) {
+    $dateInstance = CarbonImmutable::createFromDate('2024-01-03');
+    $holiday = Holidays::for(country: 'al');
+
+    $isHoliday = $holiday->isHoliday($dateInstance);
+    expect($isHoliday)->toBeFalse();
+    
+    $holidayName = $holiday->getName($dateInstance);
+    expect($holidayName)->toBeNull();
+});
+
+describe('national holidays with standard dates', function() {
+    $holiday = Holidays::for(country: 'al');
+
+    it('can calculate the `Viti i Ri` holiday as expected', function() use ($holiday) {
+        $dateInstance = CarbonImmutable::createFromDate('2024-01-01');
+        
+        $isHoliday = $holiday->isHoliday($dateInstance);
+        expect($isHoliday)->toBeTrue();
+        
+        $holidayName = $holiday->getName($dateInstance);
+        expect($holidayName)->toBe('Viti i Ri');
+    });
+    
+    it('can calculate the `Dita e Verës` holiday as expected', function() use ($holiday) {
+        $dateInstance = CarbonImmutable::createFromDate('2024-03-14');
+        
+        $isHoliday = $holiday->isHoliday($dateInstance);
+        expect($isHoliday)->toBeTrue();
+        
+        $holidayName = $holiday->getName($dateInstance);
+        expect($holidayName)->toBe('Dita e Verës');
+    });
+    
+    it('can calculate the `Dita e Sulltan Nevruzit` holiday as expected', function() use ($holiday) {
+        $dateInstance = CarbonImmutable::createFromDate('2024-03-22');
+        
+        $isHoliday = $holiday->isHoliday($dateInstance);
+        expect($isHoliday)->toBeTrue();
+        
+        $holidayName = $holiday->getName($dateInstance);
+        expect($holidayName)->toBe('Dita e Sulltan Nevruzit');
+    });
+    
+    it('can calculate the `Dita Ndërkombëtare e Punëtorëve` holiday as expected', function() use ($holiday) {
+        $dateInstance = CarbonImmutable::createFromDate('2024-05-01');
+        
+        $isHoliday = $holiday->isHoliday($dateInstance);
+        expect($isHoliday)->toBeTrue();
+        
+        $holidayName = $holiday->getName($dateInstance);
+        expect($holidayName)->toBe('Dita Ndërkombëtare e Punëtorëve');
+    });
+    
+    it('can calculate the `Dita e Shenjtërimit të Shenjt Terezës` holiday as expected', function() use ($holiday) {
+        $dateInstance = CarbonImmutable::createFromDate('2024-09-05');
+        
+        $isHoliday = $holiday->isHoliday($dateInstance);
+        expect($isHoliday)->toBeTrue();
+        
+        $holidayName = $holiday->getName($dateInstance);
+        expect($holidayName)->toBe('Dita e Shenjtërimit të Shenjt Terezës');
+    });
+    
+    it('can calculate the `Dita e Pavarësisë` holiday as expected', function() use ($holiday) {
+        $dateInstance = CarbonImmutable::createFromDate('2024-11-28');
+        
+        $isHoliday = $holiday->isHoliday($dateInstance);
+        expect($isHoliday)->toBeTrue();
+        
+        $holidayName = $holiday->getName($dateInstance);
+        expect($holidayName)->toBe('Dita e Pavarësisë');
+    });
+    
+    it('can calculate the `Dita e Çlirimit` holiday as expected', function() use ($holiday) {
+        $dateInstance = CarbonImmutable::createFromDate('2024-11-29');
+        
+        $isHoliday = $holiday->isHoliday($dateInstance);
+        expect($isHoliday)->toBeTrue();
+        
+        $holidayName = $holiday->getName($dateInstance);
+        expect($holidayName)->toBe('Dita e Çlirimit');
+    });
+    
+    it('can calculate the `Dita Kombëtare e Rinisë` holiday as expected', function() use ($holiday) {
+        $dateInstance = CarbonImmutable::createFromDate('2024-12-08');
+        
+        $isHoliday = $holiday->isHoliday($dateInstance);
+        expect($isHoliday)->toBeTrue();
+        
+        $holidayName = $holiday->getName($dateInstance);
+        expect($holidayName)->toBe('Dita Kombëtare e Rinisë');
+    });
+    
+    it('can calculate the `Krishtlindjet` holiday as expected', function() use ($holiday) {
+        $dateInstance = CarbonImmutable::createFromDate('2024-12-25');
+        
+        $isHoliday = $holiday->isHoliday($dateInstance);
+        expect($isHoliday)->toBeTrue();
+        
+        $holidayName = $holiday->getName($dateInstance);
+        expect($holidayName)->toBe('Krishtlindjet');
+    });
+ });

--- a/tests/Countries/AlbaniaTest.php
+++ b/tests/Countries/AlbaniaTest.php
@@ -111,13 +111,13 @@ describe('national holidays with standard dates', function() {
         expect($holidayName)->toBe('Dita Kombëtare e Rinisë');
     });
     
-    it('can calculate the `Krishtlindjet` holiday as expected', function() use ($holiday) {
+    it('can calculate the `Krishtlindja` holiday as expected', function() use ($holiday) {
         $dateInstance = CarbonImmutable::createFromDate('2024-12-25');
         
         $isHoliday = $holiday->isHoliday($dateInstance);
         expect($isHoliday)->toBeTrue();
         
         $holidayName = $holiday->getName($dateInstance);
-        expect($holidayName)->toBe('Krishtlindjet');
+        expect($holidayName)->toBe('Krishtlindja');
     });
  });


### PR DESCRIPTION
Official Albanian holidays, as documented by the Albanian government portal [https://e-albania.al/Pages/OfficialHolidays.aspx](https://e-albania.al/Pages/OfficialHolidays.aspx)
Includes tentative dates for `Eid al-Fitr` and `Eid al-Adha` holidays until `2034`, because the dates are not static. 