### PR TITLE
Add Czechia historical data

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ use Spatie\Holidays\Holidays;
 $holidays = Holidays::for(country: 'be', year: 2024))->get();
 ```
 
+### Getting holidays between two dates
+
+You can also get all holidays between two dates (inclusive).
+
+```php
+use Spatie\Holidays\Holidays;
+
+$holidays = Holidays::for('be')->getInRange('2023-06-01', '2024-05-31');
+```
+
 ### Determining if a date is a holiday 
 
 If you need to see if a date is a holiday, you can use the `isHoliday` method.

--- a/src/Countries/Czechia.php
+++ b/src/Countries/Czechia.php
@@ -13,19 +13,43 @@ class Czechia extends Country
 
     protected function allHolidays(int $year): array
     {
-        return array_merge([
-            'Den obnovy samostatného českého státu' => '01-01',
-            'Svátek práce' => '05-01',
-            'Den vítězství' => '05-08',
-            'Den slovanských věrozvěstů Cyrila a Metoděje' => '07-05',
-            'Den upálení mistra Jana Husa' => '07-06',
-            'Den české státnosti' => '09-28',
-            'Den vzniku samostatného československého státu' => '10-28',
-            'Den boje za svobodu a demokracii a Mezinárodní den studentstva' => '11-17',
-            'Štědrý den' => '12-24',
-            '1. svátek vánoční' => '12-25',
-            '2. svátek vánoční' => '12-26',
-        ], $this->variableHolidays($year));
+        // https://kalendar.beda.cz/statni-svatky-a-vyznamne-dny-v-roce-prehledne?year=1970
+        $holidays = [
+            'Nový rok' => ['01-01', $year <= 2000],
+            'Nový rok; Den obnovy samostatného českého státu' => ['01-01', $year >= 2001],
+
+            'Svátek práce' => ['05-01', true],
+
+            'Výročí osvobození Československa Sovětskou armádou' => ['05-09', $year <= 1990],
+            'Den osvobození od fašismu' => [$year === 1991 ? '05-09' : '05-08' , $year >= 1991 && $year <= 2000],
+            'Den osvobození' => ['05-08', $year >= 2001 && $year <= 2003],
+            'Den vítězství' => ['05-08', $year >= 2004],
+
+            'Den slovanských věrozvěstů Cyrila a Metoděje' => ['07-05', $year >= 1990],
+
+            'Den upálení mistra Jana Husa' => ['07-06', $year >= 1990],
+
+            'Den české státnosti' => ['09-28', $year >= 2000],
+
+            'Vyhlášení samostatnosti ČSR; Schválení zákona o federaci' => ['10-28', $year <= 1971],
+            'Den znárodnění' => ['10-28', $year === 1972],
+            'Vyhlášení samostatnosti ČSR; Schválení zákona o federaci; Den znárodnění' => ['10-28', $year >= 1973 && $year <= 1974],
+            'Den vzniku samostatného československého státu' => ['10-28', $year >= 1988],
+
+            'Den boje za svobodu a demokracii a Mezinárodní den studentstva' => ['11-17', $year >= 2000],
+            'Štědrý den' => ['12-24', $year >= 1990],
+            '1. svátek vánoční' => ['12-25', true],
+            '2. svátek vánoční' => ['12-26', true],
+        ];
+
+        $filteredHolidays = array_map(
+            static fn (array $holiday) => $holiday[0],
+            array_filter($holidays,
+                static fn (array $holiday) => $holiday[1] === true
+            )
+        );
+
+        return array_merge($filteredHolidays, $this->variableHolidays($year));
     }
 
     /** @return array<string, CarbonImmutable> */
@@ -33,9 +57,16 @@ class Czechia extends Country
     {
         $easter = $this->easter($year);
 
-        return [
-            'Velikonoční pondělí' => $easter->addDay(),
-            'Velký pátek' => $easter->subDays(2),
+        $variableHolidays = [
+            'Velikonoční pondělí' => [$easter->addDay(), true],
+            'Velký pátek' => [$easter->subDays(2), $year >= 2016],
         ];
+
+        return array_map(
+            static fn (array $variableHoliday) => $variableHoliday[0],
+            array_filter($variableHolidays,
+                static fn (array $variableHoliday) => $variableHoliday[1] === true
+            )
+        );
     }
 }

--- a/src/Holidays.php
+++ b/src/Holidays.php
@@ -14,6 +14,8 @@ class Holidays
     protected function __construct(
         protected Country $country,
         protected int $year,
+        protected ?CarbonImmutable $from = null,
+        protected ?CarbonImmutable $to = null
     ) {
     }
 
@@ -37,6 +39,43 @@ class Holidays
         return static::for($country, $year)
             ->calculate()
             ->toArray();
+    }
+
+    /**
+     * getInRange method allows you to pick holidays in a range of dates,
+     *   - dates are inclusive.
+     *   - dates are swappable, lower date could be passed as second argument.
+     *   - dates could be a CarbonInterface or a string.
+     *   - acceptable strings formats are 'Y-m-d' or 'Y-m' or 'Y'
+     *   - if passed string is 'Y-m' or 'Y' it will be converted to first(from) / last{to} day of the month(from) / year(to)
+     * E.g. to retrieve all holidays in between
+     *    - 2020-01-01 and 2024-12-31, you could use: getInRange('2020-01-01', '2024-12-31'), getInRange('2020-01', '2024-12') or getInRange('2020', '2024')
+     *    - 2024-06-01 and 2025-05-30, you could use: getInRange('2024-06-01', '2025-05-30'), getInRange('2024-06', '2025-05')
+     * @return array<string, string> date => name
+     */
+    public function getInRange(CarbonInterface|string $from, CarbonInterface|string $to): array
+    {
+        if (! $from instanceof CarbonImmutable) {
+            $from = match (strlen($from)) {
+                4 => CarbonImmutable::parse($from . '-01-01'),
+                7 => CarbonImmutable::parse($from . '-01'),
+                default => CarbonImmutable::parse($from),
+            };
+        }
+
+        if (! $to instanceof CarbonImmutable) {
+            $to = match (strlen($to)) {
+                4 => CarbonImmutable::parse($to . '-12-31'),
+                7 => CarbonImmutable::parse($to)->endOfMonth(),
+                default => CarbonImmutable::parse($to),
+            };
+        }
+
+        if ($from->gt($to)) {
+            [$from, $to] = [$to, $from];
+        }
+
+        return $this->country->getInRange($from, $to);
     }
 
     public function isHoliday(CarbonInterface|string $date, Country|string|null $country = null): bool

--- a/tests/.pest/snapshots/Countries/CzechiaTest/it_can_calculate_czech_holidays.snap
+++ b/tests/.pest/snapshots/Countries/CzechiaTest/it_can_calculate_czech_holidays.snap
@@ -1,6 +1,6 @@
 [
     {
-        "name": "Den obnovy samostatn\u00e9ho \u010desk\u00e9ho st\u00e1tu",
+        "name": "Nov\u00fd rok; Den obnovy samostatn\u00e9ho \u010desk\u00e9ho st\u00e1tu",
         "date": "2024-01-01"
     },
     {

--- a/tests/Countries/CzechiaTest.php
+++ b/tests/Countries/CzechiaTest.php
@@ -16,3 +16,57 @@ it('can calculate czech holidays', function () {
 
     expect(formatDates($holidays))->toMatchSnapshot();
 });
+
+it ('gives right holidays for specific years', function (int $year, array $containsHolidays) {
+    $holidays = Holidays::for('cz', $year)->get();
+
+    $allHolidaysSince1970 = [
+        0 => 'Nový rok',
+        1 => 'Nový rok; Den obnovy samostatného českého státu',
+        2 => 'Svátek práce',
+        3 => 'Výročí osvobození Československa Sovětskou armádou',
+        4 => 'Den osvobození od fašismu',
+        5 => 'Den osvobození',
+        6 => 'Den vítězství',
+        7 => 'Den slovanských věrozvěstů Cyrila a Metoděje',
+        8 => 'Den upálení mistra Jana Husa',
+        9 => 'Den české státnosti',
+        10 => 'Vyhlášení samostatnosti ČSR; Schválení zákona o federaci',
+        11 => 'Den znárodnění',
+        12 => 'Vyhlášení samostatnosti ČSR; Schválení zákona o federaci; Den znárodnění',
+        13 => 'Den vzniku samostatného československého státu',
+        14 => 'Den boje za svobodu a demokracii a Mezinárodní den studentstva',
+        15 => 'Štědrý den',
+        16 => '1. svátek vánoční',
+        17 => '2. svátek vánoční',
+        // Variable:
+        18 => 'Velikonoční pondělí',
+        19 => 'Velký pátek',
+    ];
+
+    expect($holidays)->toBeArray();
+
+    $expectedHolidays = array_map(
+        static fn (int $index) => $allHolidaysSince1970[$index],
+        $containsHolidays
+    );
+
+    $givenNames = array_map(
+        static fn (array $holidayProperties) => $holidayProperties['name'],
+        $holidays
+    );
+
+    expect($givenNames)->toEqualCanonicalizing($expectedHolidays);
+})->with([
+    [1970, [0, 18, 2, 3, 10, 16, 17]],
+    [1975, [0, 18, 2, 3, 16, 17]],
+    [1980, [0, 18, 2, 3, 16, 17]],
+    [1985, [0, 18, 2, 3, 16, 17]],
+    [1990, [0, 18, 2, 3, 7, 8, 13, 15, 16, 17]],
+    [1995, [0, 18, 2, 4, 7, 8, 13, 15, 16, 17]],
+    [2000, [0, 18, 2, 4, 7, 8, 9, 13, 14, 15, 16, 17]],
+    [2005, [1, 18, 2, 6, 7, 8, 9, 13, 14, 15, 16, 17]],
+    [2010, [1, 18, 2, 6, 7, 8, 9, 13, 14, 15, 16, 17]],
+    [2015, [1, 18, 2, 6, 7, 8, 9, 13, 14, 15, 16, 17]],
+    [2020, [1, 19, 18, 2, 6, 7, 8, 9, 13, 14, 15, 16, 17]],
+]);

--- a/tests/HolidaysTest.php
+++ b/tests/HolidaysTest.php
@@ -83,3 +83,19 @@ it('can get the holiday name of a date', function () {
     $result = Holidays::for('be')->getName(CarbonImmutable::parse('2024-01-02'));
     expect($result)->toBeNull();
 });
+
+it('can get all holidays between two dates', function (string|CarbonImmutable $from, string|CarbonImmutable $to, int $expectedCount, string $firstName, string $lastName) {
+    $holidays = Holidays::for('be')->getInRange($from, $to);
+
+    expect($holidays)->toBeArray();
+    expect($holidays)->toHaveCount($expectedCount);
+    expect(reset($holidays))->toBe($firstName);
+    expect(end($holidays))->toBe($lastName);
+})->with([
+    ['2020', '2024', 50, 'Nieuwjaar', 'Kerstmis'],
+    ['2024-06', '2025-05', 9, 'Nationale Feestdag', 'OLH Hemelvaart'],
+    ['2023-06-01', '2024-05-30', 10, 'Nationale Feestdag', 'Pinkstermaandag'],
+    ['2024-05-30', '2023-06-01', 10, 'Nationale Feestdag', 'Pinkstermaandag'],
+    [CarbonImmutable::parse('2023-06-01'), CarbonImmutable::parse('2024-05-30'), 10, 'Nationale Feestdag', 'Pinkstermaandag'],
+    [CarbonImmutable::parse('2023-06-01'), '2024-05', 10, 'Nationale Feestdag', 'Pinkstermaandag'],
+]);


### PR DESCRIPTION
Current data are valid since 2016, this package support years since 1970, so holiday data for Czechia must return valid holidays for each years since 1970. This PR fixes that issue.