### PR TITLE
add wales, england, scotland and northern ireland

### DIFF
--- a/src/Countries/England.php
+++ b/src/Countries/England.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+class England extends Wales
+{
+    public function countryCode(): string
+    {
+        return 'gb-eng';
+    }
+}

--- a/src/Countries/NorthernIreland.php
+++ b/src/Countries/NorthernIreland.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+
+class NorthernIreland extends Wales
+{
+    public function countryCode(): string
+    {
+        return 'gb-nir';
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    private function stPatricksDay(int $year): array
+    {
+        $stPatricksDay = new CarbonImmutable($year . "-03-17", 'Europe/London');
+        $key = 'St Patrick\'s Day';
+
+        if ($stPatricksDay->isWeekend()) {
+            $key .= ' (substitute day)';
+            $stPatricksDay = $stPatricksDay->next('monday');
+        }
+
+        return [$key => $stPatricksDay];
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    private function battleOfTheBoyne(int $year): array
+    {
+        $battleOfTheBoyne = new CarbonImmutable($year . "-07-12", 'Europe/London');
+        $key = 'Battle of the Boyne (Orangemen\'s Day)';
+
+        if ($battleOfTheBoyne->isWeekend()) {
+            $key .= ' (substitute day)';
+            $battleOfTheBoyne = $battleOfTheBoyne->next('monday');
+        }
+
+        return [$key => $battleOfTheBoyne];
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function oneOffHolidays(int $year): array
+    {
+        return match ($year) {
+            2022 => [
+                'Platinum Jubilee bank holiday' => new CarbonImmutable("2022-06-03", 'Europe/London'),
+                'Bank Holiday for the State Funeral of Queen Elizabeth II' => new CarbonImmutable("2022-09-19", 'Europe/London'),
+            ],
+            default => [],
+        };
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function allHolidays(int $year): array
+    {
+        $regularHolidays = array_merge(
+            $this->newYearsDay($year),
+            $this->stPatricksDay($year),
+            $this->earlyMayBankHoliday($year),
+            $this->battleOfTheBoyne($year),
+            [
+                'Spring bank holiday' => new CarbonImmutable("last monday of may {$year}", 'Europe/London'),
+                'Summer bank holiday' => new CarbonImmutable("last monday of august {$year}", 'Europe/London'),
+            ],
+            $this->christmasDay($year),
+            $this->boxingDay($year),
+            $this->variableHolidays($year)
+        );
+
+        $oneOffHolidays = $this->oneOffHolidays($year);
+
+        return array_merge($regularHolidays, $oneOffHolidays);
+
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function variableHolidays(int $year): array
+    {
+        $easterSunday = $this->easter($year);
+
+        $goodFriday = $easterSunday->subDays(2);
+        $easterMonday = $easterSunday->addDay();
+
+        return [
+            'Good Friday' => $goodFriday,
+            'Easter Monday' => $easterMonday,
+        ];
+    }
+}

--- a/src/Countries/Scotland.php
+++ b/src/Countries/Scotland.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+
+class Scotland extends Wales
+{
+    public function countryCode(): string
+    {
+        return 'gb-sct';
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function secondOfJanuary(int $year): array
+    {
+        $newYearsDay = new CarbonImmutable($year . "-01-01", 'Europe/London');
+        $secondOfJanuary = new CarbonImmutable($year . "-01-02", 'Europe/London');
+        $key = '2nd January';
+
+        if ($newYearsDay->isFriday()) {
+            $key .= ' (substitute day)';
+            $secondOfJanuary = $secondOfJanuary->next('monday');
+        }
+
+        if ($newYearsDay->isWeekend()) {
+            $key .= ' (substitute day)';
+            $secondOfJanuary = $secondOfJanuary->next('tuesday');
+        }
+
+        return [$key => $secondOfJanuary];
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    private function stAndrewsDay(int $year): array
+    {
+        $stAndrewsDay = new CarbonImmutable($year . "-11-30", 'Europe/London');
+        $key = 'St Andrew\'s Day';
+
+        if ($stAndrewsDay->isWeekend()) {
+            $key .= ' (substitute day)';
+            $stAndrewsDay = $stAndrewsDay->next('monday');
+        }
+
+        return [$key => $stAndrewsDay];
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function oneOffHolidays(int $year): array
+    {
+        return match ($year) {
+            2022 => [
+                'Platinum Jubilee bank holiday' => new CarbonImmutable("2022-06-03", 'Europe/London'),
+                'Bank Holiday for the State Funeral of Queen Elizabeth II' => new CarbonImmutable("2022-09-19", 'Europe/London'),
+            ],
+            default => [],
+        };
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function allHolidays(int $year): array
+    {
+        $regularHolidays = array_merge(
+            $this->newYearsDay($year),
+            $this->secondOfJanuary($year),
+            $this->earlyMayBankHoliday($year),
+            [
+                'Spring bank holiday' => new CarbonImmutable("last monday of may {$year}", 'Europe/London'),
+                'Summer bank holiday' => new CarbonImmutable("first monday of august {$year}", 'Europe/London'),
+            ],
+            $this->stAndrewsDay($year),
+            $this->christmasDay($year),
+            $this->boxingDay($year),
+            $this->variableHolidays($year)
+        );
+
+        $oneOffHolidays = $this->oneOffHolidays($year);
+
+        return array_merge($regularHolidays, $oneOffHolidays);
+
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function variableHolidays(int $year): array
+    {
+        $easterSunday = $this->easter($year);
+
+        $goodFriday = $easterSunday->subDays(2);
+
+        return [
+            'Good Friday' => $goodFriday,
+        ];
+    }
+}

--- a/src/Countries/Wales.php
+++ b/src/Countries/Wales.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Spatie\Holidays\Countries;
+
+use Carbon\CarbonImmutable;
+
+class Wales extends Country
+{
+    public function countryCode(): string
+    {
+        return 'gb-cym';
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function christmasDay(int $year): array
+    {
+        $christmasDay = new CarbonImmutable($year . "-12-25", 'Europe/London');
+        $key = 'Christmas Day';
+
+        if ($christmasDay->isSaturday()) {
+            $key .= ' (substitute day)';
+            $christmasDay = $christmasDay->next('monday');
+        }
+
+        if ($christmasDay->isSunday()) {
+            $key .= ' (substitute day)';
+            $christmasDay = $christmasDay->next('tuesday');
+        }
+
+        return [$key => $christmasDay];
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function boxingDay(int $year): array
+    {
+        $christmasDay = new CarbonImmutable($year . "-12-25", 'Europe/London');
+        $boxingDay = new CarbonImmutable($year . "-12-26", 'Europe/London');
+        $key = 'Boxing Day';
+
+        if ($christmasDay->isFriday()) {
+            $key .= ' (substitute day)';
+            $boxingDay = $boxingDay->next('monday');
+        }
+
+        if ($christmasDay->isSaturday()) {
+            $key .= ' (substitute day)';
+            $boxingDay = $boxingDay->next('tuesday');
+        }
+
+        return [$key => $boxingDay];
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function newYearsDay(int $year): array
+    {
+        $newYearsDay = new CarbonImmutable($year . "-01-01", 'Europe/London');
+        $key = 'New Year\'s Day';
+
+        if ($newYearsDay->isWeekend()) {
+            $key .= ' (substitute day)';
+            $newYearsDay = $newYearsDay->next('monday');
+        }
+
+        return [$key => $newYearsDay];
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function earlyMayBankHoliday(int $year): array
+    {
+        if ($year === 2020) {
+            return [
+                'Early May bank holiday (VE day)' => new CarbonImmutable("2020-05-08", 'Europe/London'),
+            ];
+        }
+
+        if ($year === 2023) {
+            return [
+                'Bank holiday for the coronation of King Charles III' => new CarbonImmutable("2020-05-08", 'Europe/London'),
+            ];
+        }
+
+        return ['Early May bank holiday' => new CarbonImmutable("first monday of may {$year}", 'Europe/London')];
+    }
+
+    /**
+     * @param  int  $year
+     * @return array|CarbonImmutable[]
+     */
+    protected function oneOffHolidays(int $year): array
+    {
+        return match ($year) {
+            2022 => [
+                'Platinum Jubilee bank holiday' => new CarbonImmutable("2022-06-03", 'Europe/London'),
+                'Bank Holiday for the State Funeral of Queen Elizabeth II' => new CarbonImmutable("2022-09-19", 'Europe/London'),
+            ],
+            default => [],
+        };
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function allHolidays(int $year): array
+    {
+        $regularHolidays = array_merge(
+            $this->newYearsDay($year),
+            $this->earlyMayBankHoliday($year),
+            [
+                'Spring bank holiday' => new CarbonImmutable("last monday of may {$year}", 'Europe/London'),
+                'Summer bank holiday' => new CarbonImmutable("last monday of august {$year}", 'Europe/London'),
+            ],
+            $this->christmasDay($year),
+            $this->boxingDay($year),
+            $this->variableHolidays($year)
+        );
+
+        $oneOffHolidays = $this->oneOffHolidays($year);
+
+        return array_merge($regularHolidays, $oneOffHolidays);
+    }
+
+    /** @return array<string, CarbonImmutable> */
+    protected function variableHolidays(int $year): array
+    {
+        $easterSunday = $this->easter($year);
+
+        $goodFriday = $easterSunday->subDays(2);
+        $easterMonday = $easterSunday->addDay();
+
+        return [
+            'Good Friday' => $goodFriday,
+            'Easter Monday' => $easterMonday,
+        ];
+    }
+}

--- a/tests/.pest/snapshots/Countries/EnglandTest/it_can_calculate_holidays_for_2020.snap
+++ b/tests/.pest/snapshots/Countries/EnglandTest/it_can_calculate_holidays_for_2020.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2020-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2020-04-10"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2020-04-13"
+    },
+    {
+        "name": "Early May bank holiday (VE day)",
+        "date": "2020-05-08"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2020-05-25"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2020-08-31"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2020-12-25"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2020-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/EnglandTest/it_can_calculate_welsh_holidays.snap
+++ b/tests/.pest/snapshots/Countries/EnglandTest/it_can_calculate_welsh_holidays.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2024-03-29"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2024-04-01"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2024-05-06"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2024-05-27"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2024-08-26"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2024-12-25"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2024-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/EnglandTest/it_can_calculate_welsh_holidays_if_christmas_is_on_a_friday.snap
+++ b/tests/.pest/snapshots/Countries/EnglandTest/it_can_calculate_welsh_holidays_if_christmas_is_on_a_friday.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2020-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2020-04-10"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2020-04-13"
+    },
+    {
+        "name": "Early May bank holiday (VE day)",
+        "date": "2020-05-08"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2020-05-25"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2020-08-31"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2020-12-25"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2020-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/EnglandTest/it_can_calculate_welsh_holidays_if_christmas_is_on_a_saturday.snap
+++ b/tests/.pest/snapshots/Countries/EnglandTest/it_can_calculate_welsh_holidays_if_christmas_is_on_a_saturday.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2021-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2021-04-02"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2021-04-05"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2021-05-03"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2021-05-31"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2021-08-30"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2021-12-27"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2021-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/EnglandTest/it_can_calculate_welsh_holidays_if_christmas_is_on_a_sunday.snap
+++ b/tests/.pest/snapshots/Countries/EnglandTest/it_can_calculate_welsh_holidays_if_christmas_is_on_a_sunday.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year's Day (substitute day)",
+        "date": "2022-01-03"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2022-04-15"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2022-04-18"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2022-05-02"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2022-05-30"
+    },
+    {
+        "name": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2022-08-29"
+    },
+    {
+        "name": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2022-12-26"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2022-12-27"
+    }
+]

--- a/tests/.pest/snapshots/Countries/EnglandTest/it_returns_a_substitute_day_if_new_years_day_falls_on_a_weekend.snap
+++ b/tests/.pest/snapshots/Countries/EnglandTest/it_returns_a_substitute_day_if_new_years_day_falls_on_a_weekend.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day (substitute day)",
+        "date": "2033-01-03"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2033-04-15"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2033-04-18"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2033-05-02"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2033-05-30"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2033-08-29"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2033-12-26"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2033-12-27"
+    }
+]

--- a/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_can_calculate_northern_irish_for_2020.snap
+++ b/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_can_calculate_northern_irish_for_2020.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2020-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2020-04-10"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2020-04-13"
+    },
+    {
+        "name": "Early May bank holiday (VE day)",
+        "date": "2020-05-08"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2020-05-25"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2020-08-31"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2020-12-25"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2020-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_can_calculate_northern_irish_holidays.snap
+++ b/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_can_calculate_northern_irish_holidays.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2025-01-01"
+    },
+    {
+        "name": "St Patrick's Day",
+        "date": "2025-03-17"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2025-04-18"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2025-04-21"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2025-05-05"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2025-05-26"
+    },
+    {
+        "name": "Battle of the Boyne (Orangemen's Day) (substitute day)",
+        "date": "2025-07-14"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2025-08-25"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2025-12-25"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2025-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_can_calculate_northern_irish_holidays_if_christmas_is_on_a_friday.snap
+++ b/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_can_calculate_northern_irish_holidays_if_christmas_is_on_a_friday.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2020-01-01"
+    },
+    {
+        "name": "St Patrick's Day",
+        "date": "2020-03-17"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2020-04-10"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2020-04-13"
+    },
+    {
+        "name": "Early May bank holiday (VE day)",
+        "date": "2020-05-08"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2020-05-25"
+    },
+    {
+        "name": "Battle of the Boyne (Orangemen's Day) (substitute day)",
+        "date": "2020-07-13"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2020-08-31"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2020-12-25"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2020-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_can_calculate_northern_irish_holidays_if_christmas_is_on_a_saturday.snap
+++ b/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_can_calculate_northern_irish_holidays_if_christmas_is_on_a_saturday.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2021-01-01"
+    },
+    {
+        "name": "St Patrick's Day",
+        "date": "2021-03-17"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2021-04-02"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2021-04-05"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2021-05-03"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2021-05-31"
+    },
+    {
+        "name": "Battle of the Boyne (Orangemen's Day)",
+        "date": "2021-07-12"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2021-08-30"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2021-12-27"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2021-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_can_calculate_northern_irish_holidays_if_christmas_is_on_a_sunday.snap
+++ b/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_can_calculate_northern_irish_holidays_if_christmas_is_on_a_sunday.snap
@@ -1,0 +1,50 @@
+[
+    {
+        "name": "New Year's Day (substitute day)",
+        "date": "2022-01-03"
+    },
+    {
+        "name": "St Patrick's Day",
+        "date": "2022-03-17"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2022-04-15"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2022-04-18"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2022-05-02"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2022-05-30"
+    },
+    {
+        "name": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03"
+    },
+    {
+        "name": "Battle of the Boyne (Orangemen's Day)",
+        "date": "2022-07-12"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2022-08-29"
+    },
+    {
+        "name": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2022-12-26"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2022-12-27"
+    }
+]

--- a/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_returns_a_substitute_day_for_second_of_january_if_new_years_day_falls_on_a_friday.snap
+++ b/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_returns_a_substitute_day_for_second_of_january_if_new_years_day_falls_on_a_friday.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2021-01-01"
+    },
+    {
+        "name": "St Patrick's Day",
+        "date": "2021-03-17"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2021-04-02"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2021-04-05"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2021-05-03"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2021-05-31"
+    },
+    {
+        "name": "Battle of the Boyne (Orangemen's Day)",
+        "date": "2021-07-12"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2021-08-30"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2021-12-27"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2021-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_returns_a_substitute_day_if_new_years_day_falls_on_a_weekend.snap
+++ b/tests/.pest/snapshots/Countries/NorthernIrelandTest/it_returns_a_substitute_day_if_new_years_day_falls_on_a_weekend.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year's Day (substitute day)",
+        "date": "2033-01-03"
+    },
+    {
+        "name": "St Patrick's Day",
+        "date": "2033-03-17"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2033-04-15"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2033-04-18"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2033-05-02"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2033-05-30"
+    },
+    {
+        "name": "Battle of the Boyne (Orangemen's Day)",
+        "date": "2033-07-12"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2033-08-29"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2033-12-26"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2033-12-27"
+    }
+]

--- a/tests/.pest/snapshots/Countries/ScotlandTest/it_can_calculate_holidays_for_2020.snap
+++ b/tests/.pest/snapshots/Countries/ScotlandTest/it_can_calculate_holidays_for_2020.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2020-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2020-04-10"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2020-04-13"
+    },
+    {
+        "name": "Early May bank holiday (VE day)",
+        "date": "2020-05-08"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2020-05-25"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2020-08-31"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2020-12-25"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2020-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/ScotlandTest/it_can_calculate_scottish_holidays.snap
+++ b/tests/.pest/snapshots/Countries/ScotlandTest/it_can_calculate_scottish_holidays.snap
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2025-01-01"
+    },
+    {
+        "name": "2nd January",
+        "date": "2025-01-02"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2025-04-18"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2025-05-05"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2025-05-26"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2025-08-04"
+    },
+    {
+        "name": "St Andrew's Day (substitute day)",
+        "date": "2025-12-01"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2025-12-25"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2025-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/ScotlandTest/it_can_calculate_scottish_holidays_if_christmas_is_on_a_friday.snap
+++ b/tests/.pest/snapshots/Countries/ScotlandTest/it_can_calculate_scottish_holidays_if_christmas_is_on_a_friday.snap
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2020-01-01"
+    },
+    {
+        "name": "2nd January",
+        "date": "2020-01-02"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2020-04-10"
+    },
+    {
+        "name": "Early May bank holiday (VE day)",
+        "date": "2020-05-08"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2020-05-25"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2020-08-03"
+    },
+    {
+        "name": "St Andrew's Day",
+        "date": "2020-11-30"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2020-12-25"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2020-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/ScotlandTest/it_can_calculate_scottish_holidays_if_christmas_is_on_a_saturday.snap
+++ b/tests/.pest/snapshots/Countries/ScotlandTest/it_can_calculate_scottish_holidays_if_christmas_is_on_a_saturday.snap
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2021-01-01"
+    },
+    {
+        "name": "2nd January (substitute day)",
+        "date": "2021-01-04"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2021-04-02"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2021-05-03"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2021-05-31"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2021-08-02"
+    },
+    {
+        "name": "St Andrew's Day",
+        "date": "2021-11-30"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2021-12-27"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2021-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/ScotlandTest/it_can_calculate_scottish_holidays_if_christmas_is_on_a_sunday.snap
+++ b/tests/.pest/snapshots/Countries/ScotlandTest/it_can_calculate_scottish_holidays_if_christmas_is_on_a_sunday.snap
@@ -1,0 +1,46 @@
+[
+    {
+        "name": "New Year's Day (substitute day)",
+        "date": "2022-01-03"
+    },
+    {
+        "name": "2nd January (substitute day)",
+        "date": "2022-01-04"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2022-04-15"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2022-05-02"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2022-05-30"
+    },
+    {
+        "name": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2022-08-01"
+    },
+    {
+        "name": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19"
+    },
+    {
+        "name": "St Andrew's Day",
+        "date": "2022-11-30"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2022-12-26"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2022-12-27"
+    }
+]

--- a/tests/.pest/snapshots/Countries/ScotlandTest/it_returns_a_substitute_day_for_second_of_january_if_new_years_day_falls_on_a_friday.snap
+++ b/tests/.pest/snapshots/Countries/ScotlandTest/it_returns_a_substitute_day_for_second_of_january_if_new_years_day_falls_on_a_friday.snap
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2021-01-01"
+    },
+    {
+        "name": "2nd January (substitute day)",
+        "date": "2021-01-04"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2021-04-02"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2021-05-03"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2021-05-31"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2021-08-02"
+    },
+    {
+        "name": "St Andrew's Day",
+        "date": "2021-11-30"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2021-12-27"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2021-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/ScotlandTest/it_returns_a_substitute_day_if_new_years_day_falls_on_a_weekend.snap
+++ b/tests/.pest/snapshots/Countries/ScotlandTest/it_returns_a_substitute_day_if_new_years_day_falls_on_a_weekend.snap
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "New Year's Day (substitute day)",
+        "date": "2033-01-03"
+    },
+    {
+        "name": "2nd January (substitute day)",
+        "date": "2033-01-04"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2033-04-15"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2033-05-02"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2033-05-30"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2033-08-01"
+    },
+    {
+        "name": "St Andrew's Day",
+        "date": "2033-11-30"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2033-12-26"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2033-12-27"
+    }
+]

--- a/tests/.pest/snapshots/Countries/WalesTest/it_can_calculate_holidays_for_2020.snap
+++ b/tests/.pest/snapshots/Countries/WalesTest/it_can_calculate_holidays_for_2020.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2020-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2020-04-10"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2020-04-13"
+    },
+    {
+        "name": "Early May bank holiday (VE day)",
+        "date": "2020-05-08"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2020-05-25"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2020-08-31"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2020-12-25"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2020-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/WalesTest/it_can_calculate_welsh_holidays.snap
+++ b/tests/.pest/snapshots/Countries/WalesTest/it_can_calculate_welsh_holidays.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2024-03-29"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2024-04-01"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2024-05-06"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2024-05-27"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2024-08-26"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2024-12-25"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2024-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/WalesTest/it_can_calculate_welsh_holidays_if_christmas_is_on_a_friday.snap
+++ b/tests/.pest/snapshots/Countries/WalesTest/it_can_calculate_welsh_holidays_if_christmas_is_on_a_friday.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2020-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2020-04-10"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2020-04-13"
+    },
+    {
+        "name": "Early May bank holiday (VE day)",
+        "date": "2020-05-08"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2020-05-25"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2020-08-31"
+    },
+    {
+        "name": "Christmas Day",
+        "date": "2020-12-25"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2020-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/WalesTest/it_can_calculate_welsh_holidays_if_christmas_is_on_a_saturday.snap
+++ b/tests/.pest/snapshots/Countries/WalesTest/it_can_calculate_welsh_holidays_if_christmas_is_on_a_saturday.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2021-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2021-04-02"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2021-04-05"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2021-05-03"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2021-05-31"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2021-08-30"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2021-12-27"
+    },
+    {
+        "name": "Boxing Day (substitute day)",
+        "date": "2021-12-28"
+    }
+]

--- a/tests/.pest/snapshots/Countries/WalesTest/it_can_calculate_welsh_holidays_if_christmas_is_on_a_sunday.snap
+++ b/tests/.pest/snapshots/Countries/WalesTest/it_can_calculate_welsh_holidays_if_christmas_is_on_a_sunday.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year's Day (substitute day)",
+        "date": "2022-01-03"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2022-04-15"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2022-04-18"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2022-05-02"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2022-05-30"
+    },
+    {
+        "name": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2022-08-29"
+    },
+    {
+        "name": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2022-12-26"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2022-12-27"
+    }
+]

--- a/tests/.pest/snapshots/Countries/WalesTest/it_returns_a_substitute_day_if_new_years_day_falls_on_a_weekend.snap
+++ b/tests/.pest/snapshots/Countries/WalesTest/it_returns_a_substitute_day_if_new_years_day_falls_on_a_weekend.snap
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "New Year's Day (substitute day)",
+        "date": "2033-01-03"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2033-04-15"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2033-04-18"
+    },
+    {
+        "name": "Early May bank holiday",
+        "date": "2033-05-02"
+    },
+    {
+        "name": "Spring bank holiday",
+        "date": "2033-05-30"
+    },
+    {
+        "name": "Summer bank holiday",
+        "date": "2033-08-29"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2033-12-26"
+    },
+    {
+        "name": "Christmas Day (substitute day)",
+        "date": "2033-12-27"
+    }
+]

--- a/tests/Countries/EnglandTest.php
+++ b/tests/Countries/EnglandTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Spatie\Holidays\Countries\Country;
+use Spatie\Holidays\Holidays;
+
+it('calculates english holidays by date', function (string $name, string $date) {
+
+    $testDate = CarbonImmutable::parse($date);
+
+    $holidayName = Holidays::for('gb-eng')->getName($testDate);
+    $isHoliday = Holidays::for('gb-eng')->isHoliday($testDate);
+
+    expect($holidayName)->toBe($name)->and($isHoliday)->toBeTrue();
+
+})->with([
+    ['New Year\'s Day', '2024-01-01'],
+    ['Good Friday', '2024-03-29'],
+    ['Easter Monday', '2024-04-01'],
+    ['Early May bank holiday', '2024-05-06'],
+    ['Spring bank holiday', '2024-05-27'],
+    ['Summer bank holiday', '2024-08-26'],
+    ['Christmas Day', '2024-12-25'],
+    ['Boxing Day', '2024-12-26'],
+    ['New Year\'s Day', '2025-01-01'],
+    ['Good Friday', '2025-04-18'],
+    ['Easter Monday', '2025-04-21'],
+    ['Early May bank holiday', '2025-05-05'],
+    ['Spring bank holiday', '2025-05-26'],
+    ['Summer bank holiday', '2025-08-25'],
+    ['Christmas Day', '2025-12-25'],
+    ['Boxing Day', '2025-12-26'],
+    ['New Year\'s Day', '2026-01-01'],
+    ['Good Friday', '2026-04-03'],
+    ['Easter Monday', '2026-04-06'],
+    ['Early May bank holiday', '2026-05-04'],
+    ['Spring bank holiday', '2026-05-25'],
+    ['Summer bank holiday', '2026-08-31'],
+    ['Christmas Day', '2026-12-25'],
+    ['Boxing Day (substitute day)', '2026-12-28'],
+]);
+
+it( 'can calculate welsh holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2024-01-01');
+
+    $holidays = Holidays::for(country: 'gb-eng')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+
+});
+
+it('returns a substitute day if new years day falls on a weekend', function () {
+    CarbonImmutable::setTestNowAndTimezone('2033-01-01');
+
+    $holidays = Holidays::for(country: 'gb-eng')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+
+
+it('can calculate welsh holidays if christmas is on a friday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2020-01-01');
+
+    $holidays = Holidays::for(country: 'gb-eng')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate welsh holidays if christmas is on a saturday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2021-01-01');
+
+    $holidays = Holidays::for(country: 'gb-eng')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate welsh holidays if christmas is on a sunday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2022-01-01');
+
+    $holidays = Holidays::for(country: 'gb-eng')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate holidays for 2020', function () {
+    CarbonImmutable::setTestNowAndTimezone('2020-01-01');
+
+    $holidays = Holidays::for(country: 'gb-eng')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+});

--- a/tests/Countries/NorthernIrelandTest.php
+++ b/tests/Countries/NorthernIrelandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use Carbon\CarbonImmutable;
+use Spatie\Holidays\Holidays;
+
+it('calculates northern irish holidays by date', function (string $name, string $date) {
+
+    $testDate = CarbonImmutable::parse($date);
+
+    $holidayName = Holidays::for('gb-nir')->getName($testDate);
+    $isHoliday = Holidays::for('gb-nir')->isHoliday($testDate);
+
+    expect($holidayName)->toBe($name)->and($isHoliday)->toBeTrue();
+
+})->with([
+    ['New Year\'s Day', '2024-01-01'],
+    ['St Patrick\'s Day (substitute day)', '2024-03-18'],
+    ['Good Friday', '2024-03-29'],
+    ['Easter Monday', '2024-04-01'],
+    ['Early May bank holiday', '2024-05-06'],
+    ['Spring bank holiday', '2024-05-27'],
+    ['Battle of the Boyne (Orangemen\'s Day)', '2024-07-12'],
+    ['Summer bank holiday', '2024-08-26'],
+    ['Christmas Day', '2024-12-25'],
+    ['Boxing Day', '2024-12-26'],
+    ['New Year\'s Day', '2025-01-01'],
+    ['St Patrick\'s Day', '2025-03-17'],
+    ['Good Friday', '2025-04-18'],
+    ['Easter Monday', '2025-04-21'],
+    ['Early May bank holiday', '2025-05-05'],
+    ['Spring bank holiday', '2025-05-26'],
+    ['Battle of the Boyne (Orangemen\'s Day) (substitute day)', '2025-07-14'],
+    ['Summer bank holiday', '2025-08-25'],
+    ['Christmas Day', '2025-12-25'],
+    ['Boxing Day', '2025-12-26'],
+    ['New Year\'s Day', '2026-01-01'],
+    ['St Patrick\'s Day', '2026-03-17'],
+    ['Good Friday', '2026-04-03'],
+    ['Easter Monday', '2026-04-06'],
+    ['Early May bank holiday', '2026-05-04'],
+    ['Spring bank holiday', '2026-05-25'],
+    ['Battle of the Boyne (Orangemen\'s Day) (substitute day)', '2026-07-13'],
+    ['Summer bank holiday', '2026-08-31'],
+    ['Christmas Day', '2026-12-25'],
+    ['Boxing Day (substitute day)', '2026-12-28'],
+
+]);
+
+it( 'can calculate northern irish holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2025-01-01');
+
+    $holidays = Holidays::for(country: 'gb-nir')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+
+});
+
+it('returns a substitute day if new years day falls on a weekend', function () {
+    CarbonImmutable::setTestNowAndTimezone('2033-01-01');
+
+    $holidays = Holidays::for(country: 'gb-nir')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('returns a substitute day for second of january if new years day falls on a friday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2021-01-01');
+
+    $holidays = Holidays::for(country: 'gb-nir')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate northern irish holidays if christmas is on a friday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2020-01-01');
+
+    $holidays = Holidays::for(country: 'gb-nir')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate northern irish holidays if christmas is on a saturday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2021-01-01');
+
+    $holidays = Holidays::for(country: 'gb-nir')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate northern irish holidays if christmas is on a sunday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2022-01-01');
+
+    $holidays = Holidays::for(country: 'gb-nir')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate northern irish for 2020', function () {
+    CarbonImmutable::setTestNowAndTimezone('2020-01-01');
+
+    $holidays = Holidays::for(country: 'gb-eng')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+});

--- a/tests/Countries/ScotlandTest.php
+++ b/tests/Countries/ScotlandTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use Carbon\CarbonImmutable;
+use Spatie\Holidays\Holidays;
+
+it('calculates scottish holidays by date', function (string $name, string $date) {
+
+    $testDate = CarbonImmutable::parse($date);
+
+    $holidayName = Holidays::for('gb-sct')->getName($testDate);
+    $isHoliday = Holidays::for('gb-sct')->isHoliday($testDate);
+
+    expect($holidayName)->toBe($name)->and($isHoliday)->toBeTrue();
+
+})->with([
+    ['New Year\'s Day', '2024-01-01'],
+    ['2nd January', '2024-01-02'],
+    ['Good Friday', '2024-03-29'],
+    ['Early May bank holiday', '2024-05-06'],
+    ['Spring bank holiday', '2024-05-27'],
+    ['Summer bank holiday', '2024-08-05'],
+    ['St Andrew\'s Day (substitute day)', '2024-12-02'],
+    ['Christmas Day', '2024-12-25'],
+    ['Boxing Day', '2024-12-26'],
+    ['New Year\'s Day', '2025-01-01'],
+    ['2nd January', '2025-01-02'],
+    ['Good Friday', '2025-04-18'],
+    ['Early May bank holiday', '2025-05-05'],
+    ['Spring bank holiday', '2025-05-26'],
+    ['Summer bank holiday', '2025-08-04'],
+    ['St Andrew\'s Day (substitute day)', '2025-12-01'],
+    ['Christmas Day', '2025-12-25'],
+    ['Boxing Day', '2025-12-26'],
+    ['New Year\'s Day', '2026-01-01'],
+    ['2nd January', '2026-01-02'],
+    ['Good Friday', '2026-04-03'],
+    ['Early May bank holiday', '2026-05-04'],
+    ['Spring bank holiday', '2026-05-25'],
+    ['Summer bank holiday', '2026-08-03'],
+    ['St Andrew\'s Day', '2026-11-30'],
+    ['Christmas Day', '2026-12-25'],
+    ['Boxing Day (substitute day)', '2026-12-28'],
+]);
+
+
+it( 'can calculate scottish holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2025-01-01');
+
+    $holidays = Holidays::for(country: 'gb-sct')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+
+});
+
+it('returns a substitute day if new years day falls on a weekend', function () {
+    CarbonImmutable::setTestNowAndTimezone('2033-01-01');
+
+    $holidays = Holidays::for(country: 'gb-sct')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('returns a substitute day for second of january if new years day falls on a friday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2021-01-01');
+
+    $holidays = Holidays::for(country: 'gb-sct')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate scottish holidays if christmas is on a friday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2020-01-01');
+
+    $holidays = Holidays::for(country: 'gb-sct')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate scottish holidays if christmas is on a saturday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2021-01-01');
+
+    $holidays = Holidays::for(country: 'gb-sct')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate scottish holidays if christmas is on a sunday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2022-01-01');
+
+    $holidays = Holidays::for(country: 'gb-sct')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate holidays for 2020', function () {
+    CarbonImmutable::setTestNowAndTimezone('2020-01-01');
+
+    $holidays = Holidays::for(country: 'gb-eng')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty()
+        ->and(formatDates($holidays))->toMatchSnapshot();
+});

--- a/tests/Countries/WalesTest.php
+++ b/tests/Countries/WalesTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Spatie\Holidays\Countries\Country;
+use Spatie\Holidays\Holidays;
+
+it('calculates welsh holidays by date', function (string $name, string $date) {
+
+    $testDate = CarbonImmutable::parse($date);
+
+    $holidayName = Holidays::for('gb-cym')->getName($testDate);
+    $isHoliday = Holidays::for('gb-cym')->isHoliday($testDate);
+
+    expect($holidayName)->toBe($name)->and($isHoliday)->toBeTrue();
+
+})->with([
+    ['New Year\'s Day', '2024-01-01'],
+    ['Good Friday', '2024-03-29'],
+    ['Easter Monday', '2024-04-01'],
+    ['Early May bank holiday', '2024-05-06'],
+    ['Spring bank holiday', '2024-05-27'],
+    ['Summer bank holiday', '2024-08-26'],
+    ['Christmas Day', '2024-12-25'],
+    ['Boxing Day', '2024-12-26'],
+    ['New Year\'s Day', '2025-01-01'],
+    ['Good Friday', '2025-04-18'],
+    ['Easter Monday', '2025-04-21'],
+    ['Early May bank holiday', '2025-05-05'],
+    ['Spring bank holiday', '2025-05-26'],
+    ['Summer bank holiday', '2025-08-25'],
+    ['Christmas Day', '2025-12-25'],
+    ['Boxing Day', '2025-12-26'],
+    ['New Year\'s Day', '2026-01-01'],
+    ['Good Friday', '2026-04-03'],
+    ['Easter Monday', '2026-04-06'],
+    ['Early May bank holiday', '2026-05-04'],
+    ['Spring bank holiday', '2026-05-25'],
+    ['Summer bank holiday', '2026-08-31'],
+    ['Christmas Day', '2026-12-25'],
+    ['Boxing Day (substitute day)', '2026-12-28'],
+]);
+
+it('calculates welsh easter holidays by date', function (string $name, string $date) {
+
+    $testDate = CarbonImmutable::parse($date);
+
+    $holidayName = Holidays::for('gb-cym')->getName($testDate);
+    $isHoliday = Holidays::for('gb-cym')->isHoliday($testDate);
+
+    expect($holidayName)->toBe($name)->and($isHoliday)->toBeTrue();
+
+})->with([
+    ['Good Friday', '2024-03-29'],
+    ['Easter Monday', '2024-04-01'],
+    ['Good Friday', '2025-04-18'],
+    ['Easter Monday', '2025-04-21'],
+    ['Good Friday', '2026-04-03'],
+    ['Easter Monday', '2026-04-06'],
+]);
+
+it( 'can calculate welsh holidays', function () {
+    CarbonImmutable::setTestNowAndTimezone('2024-01-01');
+
+    $holidays = Holidays::for(country: 'gb-cym')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+
+});
+
+it('returns a substitute day if new years day falls on a weekend', function () {
+    CarbonImmutable::setTestNowAndTimezone('2033-01-01');
+
+    $holidays = Holidays::for(country: 'gb-cym')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+
+
+it('can calculate welsh holidays if christmas is on a friday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2020-01-01');
+
+    $holidays = Holidays::for(country: 'gb-cym')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate welsh holidays if christmas is on a saturday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2021-01-01');
+
+    $holidays = Holidays::for(country: 'gb-cym')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate welsh holidays if christmas is on a sunday', function () {
+    CarbonImmutable::setTestNowAndTimezone('2022-01-01');
+
+    $holidays = Holidays::for(country: 'gb-cym')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('can calculate holidays for 2020', function () {
+    CarbonImmutable::setTestNowAndTimezone('2020-01-01');
+
+    $holidays = Holidays::for(country: 'gb-cym')->get();
+
+    expect($holidays)->toBeArray()->not()->toBeEmpty();
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+


### PR DESCRIPTION
This adds bank holidays for Wales, England, Scotland and Northern Ireland.

If a bank holiday is on a weekend, a ‘substitute’ weekday becomes a bank holiday, normally the following Monday.

https://www.gov.uk/bank-holidays

### Country codes
Wales: gb-cym
England: gb-eng
Scotland: gb-sct
Northern Ireland: gb-nir
