### PR TITLE
Fixing README.md to update region parameter in country constructor to a working example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ In case your country has specific rules for calculating holidays,
 for example region specific holidays, you can pass this to the constructor of your country class.
 
 ```php
-$holidays = Holidays::for(Austria::make(region: 'de-bw'))->get();
+$holidays = Holidays::for(Germany::make(region: 'DE-BW'))->get();
 ```
 
-The value, `de-bw`, will be passed to the region parameter of the constructor of a country.
+The value, `DE-BW`, will be passed to the region parameter of the constructor of a country.
 
 ```php
-class Austria extends Country
+class Germany extends Country
 {
     protected function __construct(
         protected ?string $region = null,


### PR DESCRIPTION
Before the README.md region settings has been mixed with two different countries.
```php
$holidays = Holidays::for(Austria::make(region: 'de-bw'))->get();
```
Austria has called a German region. I´ve adjusted it to the German working example and uppercased the region parameter as it is in the German class.
