### PR TITLE
Germany: Setting some historical holidays

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ In case your country has specific rules for calculating holidays,
 for example region specific holidays, you can pass this to the constructor of your country class.
 
 ```php
-$holidays = Holidays::for(Austria::make(region: 'de-bw'))->get();
+$holidays = Holidays::for(Germany::make(region: 'DE-BW'))->get();
 ```
 
-The value, `de-bw`, will be passed to the region parameter of the constructor of a country.
+The value, `DE-BW`, will be passed to the region parameter of the constructor of a country.
 
 ```php
-class Austria extends Country
+class Germany extends Country
 {
     protected function __construct(
         protected ?string $region = null,

--- a/lang/germany/en/holidays.json
+++ b/lang/germany/en/holidays.json
@@ -17,5 +17,6 @@
     "Karfreitag": "Good Friday",
     "Ostersonntag": "Easter Sunday",
     "Internationaler Frauentag": "International Women's Day",
-    "Weltkindertag": "World Children's Day"
+    "Weltkindertag": "World Children's Day",
+    "Tag der Befreiung": "Victory in Europe Day"
 }

--- a/lang/germany/fr/holidays.json
+++ b/lang/germany/fr/holidays.json
@@ -17,5 +17,6 @@
     "Karfreitag": "Vendredi Saint",
     "Ostersonntag": "Dimanche de Pâques",
     "Internationaler Frauentag": "Journée internationale des femmes",
-    "Weltkindertag": "Journée de l'enfance"
+    "Weltkindertag": "Journée de l'enfance",
+    "Tag der Befreiung": "Fête de la Victoire"
 }

--- a/lang/germany/nl/holidays.json
+++ b/lang/germany/nl/holidays.json
@@ -17,5 +17,6 @@
     "Karfreitag": "Goede Vrijdag",
     "Ostersonntag": "Eerste paasdag",
     "Internationaler Frauentag": "Internationale vrouwendag",
-    "Weltkindertag": "Kinderdag"
+    "Weltkindertag": "Kinderdag",
+    "Tag der Befreiung": "Bevrijdingsdag"
 }

--- a/src/Countries/Germany.php
+++ b/src/Countries/Germany.php
@@ -81,23 +81,29 @@ class Germany extends Country
                     'Allerheiligen' => '11-01',
                 ];
             case 'DE-BY':
-                return [
+                $byHolidays = [
                     'Heilige Drei Könige' => '01-06',
                     'Fronleichnam' => $easter->addDays(60),
                     'Allerheiligen' => '11-01',
                     'Mariä Himmelfahrt' => '08-15',
                 ];
+                if ($year >= 1948 && $year <= 1969) {
+                    $byHolidays['Josefstag'] = '03-19';
+                }
+
+                return $byHolidays;
 
             case 'DE-BE':
+                $beHolidays = [
+                ];
                 if ($year >= 2019) {
-                    return [
-                        'Internationaler Frauentag' => '03-08',
-                    ];
-                } else {
-                    return [
-
-                    ];
+                    $beHolidays['Internationaler Frauentag'] = '03-08';
                 }
+                if ($year === 2020) {
+                    $beHolidays['Tag der Befreiung'] = '05-08';
+                }
+
+                return $beHolidays;
             case 'DE-BB':
                 if ($year >= 1991) {
                     return [

--- a/src/Countries/Germany.php
+++ b/src/Countries/Germany.php
@@ -29,7 +29,7 @@ class Germany extends Country
         $historicalHolidays = [];
         if ($year >= 1954 && $year <= 1990) {
             $historicalHolidays['Tag der deutschen Einheit'] = '06-17';
-        }else{
+        } else {
             $historicalHolidays['Tag der deutschen Einheit'] = '10-03';
         }
         if ($year >= 1990 && $year <= 1994) {

--- a/src/Countries/Germany.php
+++ b/src/Countries/Germany.php
@@ -27,6 +27,11 @@ class Germany extends Country
     protected function historicalHolidays(int $year): array
     {
         $historicalHolidays = [];
+        if ($year >= 1954 && $year <= 1990) {
+            $historicalHolidays['Tag der deutschen Einheit'] = '06-17';
+        }else{
+            $historicalHolidays['Tag der deutschen Einheit'] = '10-03';
+        }
         if ($year >= 1990 && $year <= 1994) {
             $historicalHolidays['Buß- und Bettag'] = $this->getRepentanceAndPrayerDay($year);
         }
@@ -43,7 +48,6 @@ class Germany extends Country
 
         return array_merge([
             'Neujahr' => '01-01',
-            'Tag der deutschen Einheit' => '10-03',
             'Tag der Arbeit' => '05-01',
             '1. Weihnachtstag' => '12-25',
             '2. Weihnachtstag' => '12-26',

--- a/tests/Countries/GermanyTest.php
+++ b/tests/Countries/GermanyTest.php
@@ -18,7 +18,22 @@ it('can calculate german holidays', function () {
     expect(formatDates($holidays))->toMatchSnapshot();
 
 });
+it('can calculate german historical unity day in year 1990', function () {
+    CarbonImmutable::setTestNow('1990-01-01');
 
+    $holiday = Holidays::for('de')->isHoliday('1990-06-17');
+
+    expect($holiday)->toBeTrue();
+
+});
+it('can calculate german unity day in year 1990', function () {
+    CarbonImmutable::setTestNow('2024-01-01');
+
+    $holiday = Holidays::for('de')->isHoliday('2024-10-03');
+
+    expect($holiday)->toBeTrue();
+
+});
 it('can calculate german historical reformationstag in year 2017', function () {
     CarbonImmutable::setTestNow('2017-01-01');
 

--- a/tests/Countries/GermanyTest.php
+++ b/tests/Countries/GermanyTest.php
@@ -59,6 +59,14 @@ it('can calculate german buß- und bettag in year 1990', function () {
     expect($holiday)->toBeTrue();
 
 });
+it('can calculate german berlin holiday Victory in Europe Day in year 2020', function () {
+    CarbonImmutable::setTestNow('2020-01-01');
+
+    $holiday = Holidays::for(Germany::make('DE-BE'))->isHoliday('2020-05-08');
+
+    expect($holiday)->toBeTrue();
+
+});
 /*
  This test will check for all regional holidays in Germany. Source: https://en.wikipedia.org/wiki/Public_holidays_in_Germany
     The total numbers are referenced in the wikipedia article.

--- a/tests/Countries/GermanyTest.php
+++ b/tests/Countries/GermanyTest.php
@@ -39,7 +39,7 @@ it('can calculate german historical reformationstag in year 2018 is not a holida
 it('can calculate german buß- und bettag in year 1990', function () {
     CarbonImmutable::setTestNow('1990-01-01');
 
-    $holiday = Holidays::for('de')->isHoliday('1990-10-03');
+    $holiday = Holidays::for('de')->isHoliday('1990-11-21');
 
     expect($holiday)->toBeTrue();
 


### PR DESCRIPTION
Added:

- [Uprising Day](https://en.wikipedia.org/wiki/East_German_uprising_of_1953) (17 June) This day was public holiday under the title of "German Unity Day" from 1954 until 1990 when that unity actually was achieved.
- Saint Joseph's Day was a holidays in Bavaria after WW2 until 1969
- In 2020, a regional holiday in Berlin occurred on 8 May to mark the [75th anniversary of surrender](https://en.wikipedia.org/wiki/Victory_in_Europe_Day)
- Added the translations for the dates above

Fixed:
- Test case for buß und bettag was set to reformationstag