### PR TITLE
Fix Danish Easter dates offset

### DIFF
--- a/src/Countries/Denmark.php
+++ b/src/Countries/Denmark.php
@@ -27,10 +27,10 @@ class Denmark extends Country
         $easter = $this->easter($year);
 
         $holidays = [
-            'Påskedag' => $easter->addDay(),
             'Skærtorsdag' => $easter->subDays(3),
             'Langfredag' => $easter->subDays(2),
-            'Anden Påskedag' => $easter->addDays(2),
+            'Påskedag' => $easter,
+            'Anden Påskedag' => $easter->addDay(),
             'Kristi Himmelfartsdag' => $easter->addDays(39),
             'Pinse' => $easter->addDays(49),
             'Anden Pinsedag' => $easter->addDays(50),

--- a/tests/.pest/snapshots/Countries/DenmarkTest/it_can_calculate_danish_holidays.snap
+++ b/tests/.pest/snapshots/Countries/DenmarkTest/it_can_calculate_danish_holidays.snap
@@ -13,11 +13,11 @@
     },
     {
         "name": "P\u00e5skedag",
-        "date": "2024-04-01"
+        "date": "2024-03-31"
     },
     {
         "name": "Anden P\u00e5skedag",
-        "date": "2024-04-02"
+        "date": "2024-04-01"
     },
     {
         "name": "Kristi Himmelfartsdag",


### PR DESCRIPTION
Easter sunday and monday are offset by one day.

Also moved the days to be in chronological order.