### PR TITLE
Fix: Canada Victoria Day correction in test and calculation

### DIFF
--- a/src/Countries/Canada.php
+++ b/src/Countries/Canada.php
@@ -31,11 +31,9 @@ class Canada extends Country
     {
         $easter = $this->easter($year);
 
-        $victoriaDay = (new CarbonImmutable("last monday of May $year"))->startOfDay();
-
-        if ($victoriaDay->day < 25) {
-            $victoriaDay = $victoriaDay->addWeek();
-        }
+        // the Monday preceding May 25
+        $victoriaDay = CarbonImmutable::createFromFormat( 'Y-m-d', "{$year}-05-25" )
+            ->previous('Monday');
 
         return [
             'Victoria Day' => $victoriaDay,

--- a/tests/.pest/snapshots/Countries/CanadaTest/it_can_calculate_canadian_holidays.snap
+++ b/tests/.pest/snapshots/Countries/CanadaTest/it_can_calculate_canadian_holidays.snap
@@ -13,7 +13,7 @@
     },
     {
         "name": "Victoria Day",
-        "date": "2024-05-27"
+        "date": "2024-05-20"
     },
     {
         "name": "Canada Day",


### PR DESCRIPTION
Corrected the Victoria Day date for 2024 to be May 20th in test snapshot, not May 27th.

Corrected the code in src/Countries/Canada.php to calculate the correct date for Victoria Day.

Canada Victoria Day is always the first Monday in May preceding May 25th(and not including).
The Monday will always be between May 18th and May 24th.


