### PR TITLE
feat: remove canceled day of the rest from `Slovakia` country

### DIFF
--- a/src/Countries/Slovakia.php
+++ b/src/Countries/Slovakia.php
@@ -20,7 +20,6 @@ class Slovakia extends Country
             'Deň víťazstva nad fašizmom' => '05-08',
             'Sviatok svätého Cyrila a Metoda' => '07-05',
             'Výročie Slovenského národného povstania' => '08-29',
-            'Deň Ústavy Slovenskej republiky' => '09-01',
             'Sedembolestná Panna Mária' => '09-15',
             'Sviatok všetkých svätých' => '11-01',
             'Deň boja za slobodu a demokraciu' => '11-17',

--- a/tests/.pest/snapshots/Countries/SlovakiaTest/it_can_calculate_slovak_holidays.snap
+++ b/tests/.pest/snapshots/Countries/SlovakiaTest/it_can_calculate_slovak_holidays.snap
@@ -32,10 +32,6 @@
         "date": "2024-08-29"
     },
     {
-        "name": "De\u0148 \u00dastavy Slovenskej republiky",
-        "date": "2024-09-01"
-    },
-    {
         "name": "Sedembolestn\u00e1 Panna M\u00e1ria",
         "date": "2024-09-15"
     },


### PR DESCRIPTION
This PR remove `Deň Ústavy Slovenskej republiky` from holidays, because this holiday is not day of the rest anymore.

Source: https://www.relia.sk/Article.aspx?ID=1056
