### PR TITLE
Update README.md to remove named parameter from make

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In case your country has specific rules for calculating holidays,
 for example region specific holidays, you can pass this to the constructor of your country class.
 
 ```php
-$holidays = Holidays::for(Germany::make(region: 'DE-BW'))->get();
+$holidays = Holidays::for(Germany::make('DE-BW'))->get();
 ```
 
 The value, `DE-BW`, will be passed to the region parameter of the constructor of a country.


### PR DESCRIPTION
Named parameters are not handled correct by the ::make() which calls func_get_args(). Remove the parameter region to make example work.

Details and fixes #213
