### PR TITLE
update(holiday): Utamaduni day renamed to Mazingira day

### DIFF
--- a/src/Countries/Kenya.php
+++ b/src/Countries/Kenya.php
@@ -17,7 +17,7 @@ class Kenya extends Country
             "New Year's Day" => '01-01',
             'Labour day' => '05-01',
             'Madaraka Day' => '06-01',
-            'Mazingira Day' => '10-10',
+            $this->getOctober10HolidayName($year) => '10-10',
             'Mashujaa Day' => '10-20',
             'Jamhuri Day' => '12-01',
             'Christmas' => '12-25',
@@ -34,5 +34,16 @@ class Kenya extends Country
             'Good Friday' => $easter->subDays(2),
             'Easter Monday' => $easter->addDay(),
         ];
+    }
+
+    /** @return string */
+    protected function getOctober10HolidayName(int $year): string
+    {
+        return match (true) {
+            $year >= 2024 => 'Mazingira Day',
+            $year >= 2022 => 'Utamaduni Day',
+            $year >= 2019 => 'Huduma Day',
+            default => 'Moi Day'
+        };
     }
 }

--- a/src/Countries/Kenya.php
+++ b/src/Countries/Kenya.php
@@ -14,14 +14,14 @@ class Kenya extends Country
     protected function allHolidays(int $year): array
     {
         return array_merge([
-            "New Year's" => '01-01',
-            'Labour' => '05-01',
-            'Madaraka' => '06-01',
-            'Mazingira' => '10-10',
-            'Mashujaa' => '10-20',
-            'Jamhuri' => '12-01',
+            "New Year's Day" => '01-01',
+            'Labour day' => '05-01',
+            'Madaraka Day' => '06-01',
+            'Mazingira Day' => '10-10',
+            'Mashujaa Day' => '10-20',
+            'Jamhuri Day' => '12-01',
             'Christmas' => '12-25',
-            'Boxing' => '12-26',
+            'Boxing Day' => '12-26',
         ], $this->variableHolidays($year));
     }
 

--- a/src/Countries/Kenya.php
+++ b/src/Countries/Kenya.php
@@ -17,7 +17,7 @@ class Kenya extends Country
             "New Year's" => '01-01',
             'Labour' => '05-01',
             'Madaraka' => '06-01',
-            'Utamaduni' => '10-10',
+            'Mazingira' => '10-10',
             'Mashujaa' => '10-20',
             'Jamhuri' => '12-01',
             'Christmas' => '12-25',

--- a/tests/.pest/snapshots/Countries/KenyaTest/it_calculates_October_10th_holiday_as_Huduma_Day_in_2021.snap
+++ b/tests/.pest/snapshots/Countries/KenyaTest/it_calculates_October_10th_holiday_as_Huduma_Day_in_2021.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2021-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2021-04-02"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2021-04-05"
+    },
+    {
+        "name": "Labour day",
+        "date": "2021-05-01"
+    },
+    {
+        "name": "Madaraka Day",
+        "date": "2021-06-01"
+    },
+    {
+        "name": "Huduma Day",
+        "date": "2021-10-10"
+    },
+    {
+        "name": "Mashujaa Day",
+        "date": "2021-10-20"
+    },
+    {
+        "name": "Jamhuri Day",
+        "date": "2021-12-01"
+    },
+    {
+        "name": "Christmas",
+        "date": "2021-12-25"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2021-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/KenyaTest/it_calculates_October_10th_holiday_as_Mazingira_Day_in_2024.snap
+++ b/tests/.pest/snapshots/Countries/KenyaTest/it_calculates_October_10th_holiday_as_Mazingira_Day_in_2024.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2024-03-29"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2024-04-01"
+    },
+    {
+        "name": "Labour day",
+        "date": "2024-05-01"
+    },
+    {
+        "name": "Madaraka Day",
+        "date": "2024-06-01"
+    },
+    {
+        "name": "Mazingira Day",
+        "date": "2024-10-10"
+    },
+    {
+        "name": "Mashujaa Day",
+        "date": "2024-10-20"
+    },
+    {
+        "name": "Jamhuri Day",
+        "date": "2024-12-01"
+    },
+    {
+        "name": "Christmas",
+        "date": "2024-12-25"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2024-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/KenyaTest/it_calculates_October_10th_holiday_as_Moi_Day_before_2019.snap
+++ b/tests/.pest/snapshots/Countries/KenyaTest/it_calculates_October_10th_holiday_as_Moi_Day_before_2019.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2018-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2018-03-30"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2018-04-02"
+    },
+    {
+        "name": "Labour day",
+        "date": "2018-05-01"
+    },
+    {
+        "name": "Madaraka Day",
+        "date": "2018-06-01"
+    },
+    {
+        "name": "Moi Day",
+        "date": "2018-10-10"
+    },
+    {
+        "name": "Mashujaa Day",
+        "date": "2018-10-20"
+    },
+    {
+        "name": "Jamhuri Day",
+        "date": "2018-12-01"
+    },
+    {
+        "name": "Christmas",
+        "date": "2018-12-25"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2018-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/KenyaTest/it_calculates_October_10th_holiday_as_Utamaduni_Day_in_2023.snap
+++ b/tests/.pest/snapshots/Countries/KenyaTest/it_calculates_October_10th_holiday_as_Utamaduni_Day_in_2023.snap
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "New Year's Day",
+        "date": "2023-01-01"
+    },
+    {
+        "name": "Good Friday",
+        "date": "2023-04-07"
+    },
+    {
+        "name": "Easter Monday",
+        "date": "2023-04-10"
+    },
+    {
+        "name": "Labour day",
+        "date": "2023-05-01"
+    },
+    {
+        "name": "Madaraka Day",
+        "date": "2023-06-01"
+    },
+    {
+        "name": "Utamaduni Day",
+        "date": "2023-10-10"
+    },
+    {
+        "name": "Mashujaa Day",
+        "date": "2023-10-20"
+    },
+    {
+        "name": "Jamhuri Day",
+        "date": "2023-12-01"
+    },
+    {
+        "name": "Christmas",
+        "date": "2023-12-25"
+    },
+    {
+        "name": "Boxing Day",
+        "date": "2023-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/KenyaTest/it_can_calculate_kenyan_holidays.snap
+++ b/tests/.pest/snapshots/Countries/KenyaTest/it_can_calculate_kenyan_holidays.snap
@@ -1,6 +1,6 @@
 [
     {
-        "name": "New Year's",
+        "name": "New Year's Day",
         "date": "2024-01-01"
     },
     {
@@ -12,23 +12,23 @@
         "date": "2024-04-01"
     },
     {
-        "name": "Labour",
+        "name": "Labour day",
         "date": "2024-05-01"
     },
     {
-        "name": "Madaraka",
+        "name": "Madaraka Day",
         "date": "2024-06-01"
     },
     {
-        "name": "Mazingira",
+        "name": "Mazingira Day",
         "date": "2024-10-10"
     },
     {
-        "name": "Mashujaa",
+        "name": "Mashujaa Day",
         "date": "2024-10-20"
     },
     {
-        "name": "Jamhuri",
+        "name": "Jamhuri Day",
         "date": "2024-12-01"
     },
     {
@@ -36,7 +36,7 @@
         "date": "2024-12-25"
     },
     {
-        "name": "Boxing",
+        "name": "Boxing Day",
         "date": "2024-12-26"
     }
 ]

--- a/tests/.pest/snapshots/Countries/KenyaTest/it_can_calculate_kenyan_holidays.snap
+++ b/tests/.pest/snapshots/Countries/KenyaTest/it_can_calculate_kenyan_holidays.snap
@@ -20,7 +20,7 @@
         "date": "2024-06-01"
     },
     {
-        "name": "Utamaduni",
+        "name": "Mazingira",
         "date": "2024-10-10"
     },
     {

--- a/tests/Countries/KenyaTest.php
+++ b/tests/Countries/KenyaTest.php
@@ -16,3 +16,63 @@ it('can calculate kenyan holidays', function () {
 
     expect(formatDates($holidays))->toMatchSnapshot();
 });
+
+it('calculates October 10th holiday as Mazingira Day in 2024', function () {
+    CarbonImmutable::setTestNow('2024-10-10');
+
+    $holidays = Holidays::for(country: 'ke')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(findDate($holidays, 'Mazingira Day'))
+        ->toEqual(CarbonImmutable::create(2024, 10, 10));
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('calculates October 10th holiday as Utamaduni Day in 2023', function () {
+    CarbonImmutable::setTestNow('2023-10-10');
+
+    $holidays = Holidays::for(country: 'ke')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(findDate($holidays, 'Utamaduni Day'))
+        ->toEqual(CarbonImmutable::create(2023, 10, 10));
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('calculates October 10th holiday as Huduma Day in 2021', function () {
+    CarbonImmutable::setTestNow('2021-10-10');
+
+    $holidays = Holidays::for(country: 'ke')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(findDate($holidays, 'Huduma Day'))
+        ->toEqual(CarbonImmutable::create(2021, 10, 10));
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+});
+
+it('calculates October 10th holiday as Moi Day before 2019', function () {
+    CarbonImmutable::setTestNow('2018-10-10');
+
+    $holidays = Holidays::for(country: 'ke')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(findDate($holidays, 'Moi Day'))
+        ->toEqual(CarbonImmutable::create(2018, 10, 10));
+
+    expect(formatDates($holidays))->toMatchSnapshot();
+});


### PR DESCRIPTION
- This PR adds the logic required to dynamically calculate the name of the October 10th holiday in Kenya based on the year, reflecting changes from:
    * Mazingira Day [(2024 onward)](https://www.kenyans.co.ke/news/100029-utamaduni-day-renamed-mazingaira-day-after-ruto-ascents-bill)
    * Utamaduni Day [(2022-2023)](https://www.kenyans.co.ke/news/93691-cs-kithure-kindiki-gazettes-tuesday-public-holiday)
    * Huduma Day [(2019-2021)](https://www.kenyans.co.ke/news/80415-difference-between-utamaduni-huduma-days-why-there-are-no-national-events)
    * Moi Day (pre-2019).

-  Align holiday names with Public Holidays Act (Kenya)
- Utamaduni day, public holiday on October 10 was renamed Mazingira day, after the President assented the Statue Law Bill 2024.


