### PR TITLE
Regenerate pest snapshot for Argentina /  Generate pest snapshot for Indonesia test

### DIFF
--- a/tests/.pest/snapshots/Countries/ArgentineTest/it_can_calculate_argentinians_holidays.snap
+++ b/tests/.pest/snapshots/Countries/ArgentineTest/it_can_calculate_argentinians_holidays.snap
@@ -8,12 +8,28 @@
         "date": "2024-02-04"
     },
     {
+        "name": "Carnaval D\u00eda 2",
+        "date": "2024-02-13"
+    },
+    {
         "name": "Viernes Santo",
         "date": "2024-03-29"
     },
     {
+        "name": "D\u00eda Nacional de la Memoria por la Verdad y la Justicia",
+        "date": "2024-04-24"
+    },
+    {
         "name": "D\u00eda del Trabajador",
         "date": "2024-05-01"
+    },
+    {
+        "name": "Revoluci\u00f3n de Mayo",
+        "date": "2024-05-25"
+    },
+    {
+        "name": "Paso a la Inmortalidad del General Manuel Belgrano",
+        "date": "2024-06-20"
     },
     {
         "name": "D\u00eda de la Inmaculada Concepci\u00f3n de Mar\u00eda",
@@ -30,21 +46,5 @@
     {
         "name": "Navidad",
         "date": "2024-12-25"
-    },
-    {
-        "name": "Carnaval D\u00eda 2",
-        "date": "2025-01-02"
-    },
-    {
-        "name": "Paso a la Inmortalidad del General Manuel Belgrano",
-        "date": "2025-08-06"
-    },
-    {
-        "name": "D\u00eda Nacional de la Memoria por la Verdad y la Justicia",
-        "date": "2025-12-04"
-    },
-    {
-        "name": "Revoluci\u00f3n de Mayo",
-        "date": "2026-01-05"
     }
 ]

--- a/tests/.pest/snapshots/Countries/IndonesiaTest/it_can_calculate_Indonesia_holidays.snap
+++ b/tests/.pest/snapshots/Countries/IndonesiaTest/it_can_calculate_Indonesia_holidays.snap
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "Tahun Baru",
+        "date": "2024-01-01"
+    },
+    {
+        "name": "Tahun Baru Imlek",
+        "date": "2024-02-10"
+    },
+    {
+        "name": "Jumat Agung",
+        "date": "2024-03-29"
+    },
+    {
+        "name": "Hari Paskah",
+        "date": "2024-03-31"
+    },
+    {
+        "name": "Hari Buruh Internasional",
+        "date": "2024-05-01"
+    },
+    {
+        "name": "Kenaikan Yesus Kristus",
+        "date": "2024-05-09"
+    },
+    {
+        "name": "Hari Lahir Pancasila",
+        "date": "2024-06-01"
+    },
+    {
+        "name": "Hari Kemerdekaan",
+        "date": "2024-08-17"
+    },
+    {
+        "name": "Hari Raya Natal",
+        "date": "2024-12-25"
+    }
+]


### PR DESCRIPTION
This PR includes the following:

- Fix: regenerate pest snap for Argentina using the correct dates for holidays
- Chore: Generate pest snap for Indonesia test