### PR TITLE
Tweak Netherlands holidays

### DIFF
--- a/src/Countries/Netherlands.php
+++ b/src/Countries/Netherlands.php
@@ -15,7 +15,6 @@ class Netherlands extends Country
     {
         return array_merge([
             'Nieuwjaarsdag' => '01-01',
-            'Bevrijdingsdag' => '05-05',
             'Eerste kerstdag' => '12-25',
             'Tweede kerstdag' => '12-26',
         ], $this->variableHolidays($year));
@@ -32,14 +31,19 @@ class Netherlands extends Country
 
         $easter = $this->easter($year);
 
-        return [
+        $holidays = [
             'Koningsdag' => $koningsDag,
-            'Goede Vrijdag' => $easter->subDays(2),
             'Eerste paasdag' => $easter,
             'Tweede paasdag' => $easter->addDay(),
             'Hemelvaartsdag' => $easter->addDays(39),
             'Eerste pinksterdag' => $easter->addDays(49),
             'Tweede pinksterdag' => $easter->addDays(50),
         ];
+
+        if ($year % 5 === 0) {
+            $holidays['Bevrijdingsdag'] = '05-05';
+        }
+
+        return $holidays;
     }
 }

--- a/src/Countries/Netherlands.php
+++ b/src/Countries/Netherlands.php
@@ -20,7 +20,7 @@ class Netherlands extends Country
         ], $this->variableHolidays($year));
     }
 
-    /** @return array<string, CarbonImmutable> */
+    /** @return array<string, string|CarbonImmutable> */
     protected function variableHolidays(int $year): array
     {
         $koningsDag = CarbonImmutable::createFromDate($year, 4, 27);

--- a/src/Countries/Spain.php
+++ b/src/Countries/Spain.php
@@ -394,6 +394,7 @@ class Spain extends Country
         };
     }
 
+    /** @return array<string, string> */
     protected function regionHolidays2025(): array
     {
         $sanJose = ['San José' => '03-19'];

--- a/tests/.pest/snapshots/Countries/NetherlandsTest/it_can_calculate_dutch_holidays_with_bevrijdingsdag_every_5_year.snap
+++ b/tests/.pest/snapshots/Countries/NetherlandsTest/it_can_calculate_dutch_holidays_with_bevrijdingsdag_every_5_year.snap
@@ -1,38 +1,42 @@
 [
     {
         "name": "Nieuwjaarsdag",
-        "date": "2024-01-01"
+        "date": "2025-01-01"
     },
     {
         "name": "Eerste paasdag",
-        "date": "2024-03-31"
+        "date": "2025-04-20"
     },
     {
         "name": "Tweede paasdag",
-        "date": "2024-04-01"
+        "date": "2025-04-21"
     },
     {
         "name": "Koningsdag",
-        "date": "2024-04-27"
+        "date": "2025-04-26"
+    },
+    {
+        "name": "Bevrijdingsdag",
+        "date": "2025-05-05"
     },
     {
         "name": "Hemelvaartsdag",
-        "date": "2024-05-09"
+        "date": "2025-05-29"
     },
     {
         "name": "Eerste pinksterdag",
-        "date": "2024-05-19"
+        "date": "2025-06-08"
     },
     {
         "name": "Tweede pinksterdag",
-        "date": "2024-05-20"
+        "date": "2025-06-09"
     },
     {
         "name": "Eerste kerstdag",
-        "date": "2024-12-25"
+        "date": "2025-12-25"
     },
     {
         "name": "Tweede kerstdag",
-        "date": "2024-12-26"
+        "date": "2025-12-26"
     }
 ]

--- a/tests/Countries/NetherlandsTest.php
+++ b/tests/Countries/NetherlandsTest.php
@@ -15,5 +15,16 @@ it('can calculate dutch holidays', function () {
         ->not()->toBeEmpty();
 
     expect(formatDates($holidays))->toMatchSnapshot();
+});
 
+it('can calculate dutch holidays with bevrijdingsdag every 5 year', function () {
+    CarbonImmutable::setTestNow('2025-01-01');
+
+    $holidays = Holidays::for(country: 'nl')->get();
+
+    expect($holidays)
+        ->toBeArray()
+        ->not()->toBeEmpty();
+
+    expect(formatDates($holidays))->toMatchSnapshot();
 });


### PR DESCRIPTION
This PR brings the Netherlands holidays in line with official holidays:

- Bevrijdingsdag is a national holiday every 5 years (i.e. not 2024 , 2025 it is). -> Every 5 years since liberation
- Goede vrijdag isn't a national holiday