### PR TITLE
perf: implement lazy-initialized Chinese calendar formatter

### DIFF
--- a/src/Calendars/ChineseCalendar.php
+++ b/src/Calendars/ChineseCalendar.php
@@ -10,30 +10,33 @@ trait ChineseCalendar
 {
     protected string $chineseCalendarTimezone = 'Asia/Shanghai';
 
+    private ?IntlDateFormatter $formatter = null;
+
     public function setChineseCalendarTimezone(string $chineseCalendarTimezone): static
     {
-        $this->chineseCalendarTimezone = $chineseCalendarTimezone;
+        if ($this->chineseCalendarTimezone !== $chineseCalendarTimezone) {
+            $this->chineseCalendarTimezone = $chineseCalendarTimezone;
+            $this->formatter = null;
+        }
 
         return $this;
     }
 
     protected function chineseToGregorianDate(string $input, int $year): CarbonImmutable
     {
-        $timestamp = (int) $this->getFormatter()->parse($year.'-'.$input);
-
         return (new CarbonImmutable)
-            ->setTimeStamp($timestamp)
+            ->setTimestamp((int) $this->getFormatter()->parse($year.'-'.$input))
             ->setTimezone(new DateTimeZone($this->chineseCalendarTimezone));
     }
 
     protected function getFormatter(): IntlDateFormatter
     {
-        return new IntlDateFormatter(
-            locale: 'zh-CN@calendar=chinese',
-            dateType: IntlDateFormatter::SHORT,
-            timeType: IntlDateFormatter::NONE,
-            timezone: $this->chineseCalendarTimezone,
-            calendar: IntlDateFormatter::TRADITIONAL
+        return $this->formatter ??= new IntlDateFormatter(
+            'zh-CN@calendar=chinese',
+            IntlDateFormatter::SHORT,
+            IntlDateFormatter::NONE,
+            $this->chineseCalendarTimezone,
+            IntlDateFormatter::TRADITIONAL
         );
     }
 }


### PR DESCRIPTION
- Formatter initializes only upon first use
- Caches formatter for subsequent calls
- Invalidation handled on timezone changes
