### PR TITLE
Add 2 missing Slovenian holidays

### DIFF
--- a/src/Countries/Slovenia.php
+++ b/src/Countries/Slovenia.php
@@ -36,7 +36,9 @@ class Slovenia extends Country
         $easter = $this->easter($year);
 
         return [
+            'Velikonočna nedelja' => $easter, // Easter Sunday
             'Velikonočni ponedeljek' => $easter->addDay(), // Easter Monday
+            'Binkoštna nedelja' => $easter->addDays(49), // Whit Sunday
         ];
     }
 }

--- a/tests/.pest/snapshots/Countries/SloveniaTest/it_can_calculate_slovenian_holidays.snap
+++ b/tests/.pest/snapshots/Countries/SloveniaTest/it_can_calculate_slovenian_holidays.snap
@@ -12,6 +12,10 @@
         "date": "2024-02-08"
     },
     {
+        "name": "Velikono\u010dna nedelja",
+        "date": "2024-03-31"
+    },
+    {
         "name": "Velikono\u010dni ponedeljek",
         "date": "2024-04-01"
     },
@@ -26,6 +30,10 @@
     {
         "name": "Praznik dela 2",
         "date": "2024-05-02"
+    },
+    {
+        "name": "Binko\u0161tna nedelja",
+        "date": "2024-05-19"
     },
     {
         "name": "Dan dr\u017eavnosti",


### PR DESCRIPTION
Added 2 missing Slovenian holidays:
- Easter Sunday
- Whit Sunday