### PR TITLE
fix: invalid historical date for `Slovakia` country

### DIFF
--- a/src/Countries/Slovakia.php
+++ b/src/Countries/Slovakia.php
@@ -32,8 +32,9 @@ class Slovakia extends Country
             $holidays['Výročie Deklarácie slovenského národa'] = '10-30';
         }
 
+        // Until and including the year 2023, September 1st was a public holiday.
         if ($year < 2024) {
-            $holidays['Sedembolestná Panna Mária'] = '09-01';
+            $holidays['Deň Ústavy Slovenskej republiky'] = '09-01';
         }
 
         return $holidays;


### PR DESCRIPTION
This PR fixes historical date `01-09` introduced in #228 PR.

There was duplicated date for public holiday `Sedembolestná Panna Mária` and that's was wrong.

Sources:

https://sk.wikipedia.org/wiki/De%C5%88_%C3%9Astavy_Slovenskej_republiky#:~:text=De%C5%88%20%C3%9Astavy%20Slovenskej%20republiky%20je,pracovn%C3%A9ho%20pokoja.%5B1%5D

https://sk.wikipedia.org/wiki/Sedembolestn%C3%A1_Panna_M%C3%A1ria#:~:text=Sedembolestn%C3%A1%20Panna%20M%C3%A1ria%20patr%C3%B3nkou%20Slovenska.%20Dnes%20sa%20jej%20sviatok%20sl%C3%A1vi%2015.%20septembra.