### PR TITLE
fix: observe US federal holidays on nearest weekday when falling on weekend

### DIFF
--- a/src/Countries/UnitedStates.php
+++ b/src/Countries/UnitedStates.php
@@ -53,7 +53,7 @@ class UnitedStates extends Country
 
     protected function observed(string $dateString): CarbonImmutable
     {
-        $date = CarbonImmutable::createFromFormat('Y-m-d', $dateString)->startOfDay();
+        $date = new CarbonImmutable($dateString);
 
         return match ($date->dayOfWeek) {
             CarbonInterface::SATURDAY => $date->subDay(),

--- a/src/Countries/UnitedStates.php
+++ b/src/Countries/UnitedStates.php
@@ -4,6 +4,7 @@ namespace Spatie\Holidays\Countries;
 
 use Carbon\CarbonImmutable;
 use Spatie\Holidays\Holiday;
+use Carbon\CarbonInterface;
 
 class UnitedStates extends Country
 {
@@ -14,18 +15,27 @@ class UnitedStates extends Country
 
     protected function allHolidays(int $year): array
     {
-        $holidays = array_merge([
-            Holiday::national("New Year's Day", "{$year}-01-01"),
-            Holiday::national('Independence Day', "{$year}-07-04"),
-            Holiday::national('Veterans Day', "{$year}-11-11"),
-            Holiday::national('Christmas', "{$year}-12-25"),
-        ], $this->variableHolidays($year));
+        $holidays = array_merge(
+            $this->fixedHolidays($year),
+            $this->variableHolidays($year),
+        );
 
         if ($year >= 2021) {
-            $holidays[] = Holiday::national('Juneteenth National Independence Day', "{$year}-06-19");
+            $holidays[] = Holiday::national('Juneteenth National Independence Day', $this->observed("{$year}-06-19"));
         }
 
         return $holidays;
+    }
+
+    /** @return array<Holiday> */
+    protected function fixedHolidays(int $year): array
+    {
+        return [
+            Holiday::national("New Year's Day", $this->observed("{$year}-01-01")),
+            Holiday::national('Independence Day', $this->observed("{$year}-07-04")),
+            Holiday::national('Veterans Day', $this->observed("{$year}-11-11")),
+            Holiday::national('Christmas', $this->observed("{$year}-12-25")),
+        ];
     }
 
     /** @return array<Holiday> */
@@ -39,5 +49,16 @@ class UnitedStates extends Country
             Holiday::national('Columbus Day', CarbonImmutable::parse("second monday of October {$year}")),
             Holiday::national('Thanksgiving', CarbonImmutable::parse("fourth thursday of November {$year}")),
         ];
+    }
+
+    protected function observed(string $dateString): CarbonImmutable
+    {
+        $date = CarbonImmutable::createFromFormat('Y-m-d', $dateString)->startOfDay();
+
+        return match ($date->dayOfWeek) {
+            CarbonInterface::SATURDAY => $date->subDay(),
+            CarbonInterface::SUNDAY => $date->addDay(),
+            default => $date,
+        };
     }
 }

--- a/tests/.pest/snapshots/Countries/UnitedStatesTest/it_can_calculate_united_states_holidays_before_2021.snap
+++ b/tests/.pest/snapshots/Countries/UnitedStatesTest/it_can_calculate_united_states_holidays_before_2021.snap
@@ -17,7 +17,7 @@
     },
     {
         "name": "Independence Day",
-        "date": "2020-07-04"
+        "date": "2020-07-03"
     },
     {
         "name": "Labor Day",

--- a/tests/Countries/UnitedStatesTest.php
+++ b/tests/Countries/UnitedStatesTest.php
@@ -30,3 +30,31 @@ it('can calculate united states holidays before 2021', function () {
     expect(formatDates($holidays))->toMatchSnapshot();
 
 });
+
+it('observes saturday holidays on preceding friday', function () {
+    CarbonImmutable::setTestNow('2026-01-01');
+
+    $holidays = Holidays::for(country: 'us')->get();
+    $formattedHolidays = formatDates($holidays);
+    $byName = [];
+    foreach ($formattedHolidays as $h) {
+        $byName[$h['name']] = $h['date'];
+    }
+
+    expect($byName['Independence Day'])->toBe('2026-07-03');
+});
+
+it('observes sunday holidays on following monday', function () {
+    CarbonImmutable::setTestNow('2027-01-01');
+
+    $holidays = Holidays::for(country: 'us')->get();
+    $formattedHolidays = formatDates($holidays);
+    $byName = [];
+    foreach ($formattedHolidays as $h) {
+        $byName[$h['name']] = $h['date'];
+    }
+
+    expect($byName['Independence Day'])->toBe('2027-07-05');
+    expect($byName['Juneteenth National Independence Day'])->toBe('2027-06-18');
+    expect($byName['Christmas'])->toBe('2027-12-24');
+});


### PR DESCRIPTION
## Summary

- Fixed-date US federal holidays (New Year's Day, Juneteenth, Independence Day, Veterans Day, Christmas) now shift to the nearest weekday when falling on a weekend, per [5 U.S.C. 6103(b)](https://www.law.cornell.edu/uscode/text/5/6103) and [Executive Order 11582](https://www.archives.gov/federal-register/codification/executive-order/11582.html)
- Saturday → observed on preceding Friday
- Sunday → observed on following Monday
- Verified against the [OPM Federal Holiday Schedule](https://www.opm.gov/policy-data-oversight/snow-dismissal-procedures/federal-holidays/) for 2020, 2024, 2026, and 2027

## Changes

| File | What |
|---|---|
| `src/Countries/UnitedStates.php` | Added `observed()` method with `match` on day-of-week, applied to all fixed-date holidays |
| `tests/Countries/UnitedStatesTest.php` | Added tests for Saturday (2026) and Sunday (2027) weekend observance |
| `it_can_calculate_united_states_holidays_before_2021.snap` | Updated snapshot (2020-07-04 was Saturday → now 2020-07-03) |

## Test plan

- [x] `pint --test` passes (PSR-12)
- [x] `phpstan analyse` — 0 errors
- [x] Full test suite: 513 passed (1292 assertions)
- [x] Output verified against OPM federal calendar for 2026 and 2027