### PR TITLE
fix: add Easter Sunday and use official Epiphany name for Croatia

### DIFF
--- a/src/Countries/Croatia.php
+++ b/src/Countries/Croatia.php
@@ -15,7 +15,7 @@ class Croatia extends Country
     {
         return array_merge([
             Holiday::national('Nova godina', "{$year}-01-01"),
-            Holiday::national('Bogojavljenje', "{$year}-01-06"),
+            Holiday::national('Bogojavljenje ili Sveta tri kralja', "{$year}-01-06"),
             Holiday::national('Praznik rada', "{$year}-05-01"),
             Holiday::national('Dan državnosti', "{$year}-05-30"),
             Holiday::national('Dan antifašističke borbe', "{$year}-06-22"),
@@ -34,6 +34,7 @@ class Croatia extends Country
         $easter = $this->easter($year);
 
         return [
+            Holiday::national('Uskrs', $easter),
             Holiday::national('Uskrsni ponedjeljak', $easter->addDay()),
             Holiday::national('Tijelovo', $easter->addDays(60)),
         ];

--- a/tests/.pest/snapshots/Countries/CroatiaTest/it_can_calculate_croatian_holidays_with_data_set___2024__.snap
+++ b/tests/.pest/snapshots/Countries/CroatiaTest/it_can_calculate_croatian_holidays_with_data_set___2024__.snap
@@ -4,8 +4,12 @@
         "date": "2024-01-01"
     },
     {
-        "name": "Bogojavljenje",
+        "name": "Bogojavljenje ili Sveta tri kralja",
         "date": "2024-01-06"
+    },
+    {
+        "name": "Uskrs",
+        "date": "2024-03-31"
     },
     {
         "name": "Uskrsni ponedjeljak",

--- a/tests/.pest/snapshots/Countries/CroatiaTest/it_can_calculate_croatian_holidays_with_data_set___2025__.snap
+++ b/tests/.pest/snapshots/Countries/CroatiaTest/it_can_calculate_croatian_holidays_with_data_set___2025__.snap
@@ -1,0 +1,58 @@
+[
+    {
+        "name": "Nova godina",
+        "date": "2025-01-01"
+    },
+    {
+        "name": "Bogojavljenje ili Sveta tri kralja",
+        "date": "2025-01-06"
+    },
+    {
+        "name": "Uskrs",
+        "date": "2025-04-20"
+    },
+    {
+        "name": "Uskrsni ponedjeljak",
+        "date": "2025-04-21"
+    },
+    {
+        "name": "Praznik rada",
+        "date": "2025-05-01"
+    },
+    {
+        "name": "Dan dr\u017eavnosti",
+        "date": "2025-05-30"
+    },
+    {
+        "name": "Tijelovo",
+        "date": "2025-06-19"
+    },
+    {
+        "name": "Dan antifa\u0161isti\u010dke borbe",
+        "date": "2025-06-22"
+    },
+    {
+        "name": "Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja",
+        "date": "2025-08-05"
+    },
+    {
+        "name": "Velika Gospa",
+        "date": "2025-08-15"
+    },
+    {
+        "name": "Svi sveti",
+        "date": "2025-11-01"
+    },
+    {
+        "name": "Dan sje\u0107anja na \u017ertve Domovinskog rata i Dan sje\u0107anja na \u017ertvu Vukovara i \u0160kabrnje",
+        "date": "2025-11-18"
+    },
+    {
+        "name": "Bo\u017ei\u0107",
+        "date": "2025-12-25"
+    },
+    {
+        "name": "Sveti Stjepan",
+        "date": "2025-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/CroatiaTest/it_can_calculate_croatian_holidays_with_data_set___2026__.snap
+++ b/tests/.pest/snapshots/Countries/CroatiaTest/it_can_calculate_croatian_holidays_with_data_set___2026__.snap
@@ -1,0 +1,58 @@
+[
+    {
+        "name": "Nova godina",
+        "date": "2026-01-01"
+    },
+    {
+        "name": "Bogojavljenje ili Sveta tri kralja",
+        "date": "2026-01-06"
+    },
+    {
+        "name": "Uskrs",
+        "date": "2026-04-05"
+    },
+    {
+        "name": "Uskrsni ponedjeljak",
+        "date": "2026-04-06"
+    },
+    {
+        "name": "Praznik rada",
+        "date": "2026-05-01"
+    },
+    {
+        "name": "Dan dr\u017eavnosti",
+        "date": "2026-05-30"
+    },
+    {
+        "name": "Tijelovo",
+        "date": "2026-06-04"
+    },
+    {
+        "name": "Dan antifa\u0161isti\u010dke borbe",
+        "date": "2026-06-22"
+    },
+    {
+        "name": "Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja",
+        "date": "2026-08-05"
+    },
+    {
+        "name": "Velika Gospa",
+        "date": "2026-08-15"
+    },
+    {
+        "name": "Svi sveti",
+        "date": "2026-11-01"
+    },
+    {
+        "name": "Dan sje\u0107anja na \u017ertve Domovinskog rata i Dan sje\u0107anja na \u017ertvu Vukovara i \u0160kabrnje",
+        "date": "2026-11-18"
+    },
+    {
+        "name": "Bo\u017ei\u0107",
+        "date": "2026-12-25"
+    },
+    {
+        "name": "Sveti Stjepan",
+        "date": "2026-12-26"
+    }
+]

--- a/tests/.pest/snapshots/Countries/CroatiaTest/it_can_calculate_croatian_holidays_with_data_set___2027__.snap
+++ b/tests/.pest/snapshots/Countries/CroatiaTest/it_can_calculate_croatian_holidays_with_data_set___2027__.snap
@@ -1,0 +1,58 @@
+[
+    {
+        "name": "Nova godina",
+        "date": "2027-01-01"
+    },
+    {
+        "name": "Bogojavljenje ili Sveta tri kralja",
+        "date": "2027-01-06"
+    },
+    {
+        "name": "Uskrs",
+        "date": "2027-03-28"
+    },
+    {
+        "name": "Uskrsni ponedjeljak",
+        "date": "2027-03-29"
+    },
+    {
+        "name": "Praznik rada",
+        "date": "2027-05-01"
+    },
+    {
+        "name": "Tijelovo",
+        "date": "2027-05-27"
+    },
+    {
+        "name": "Dan dr\u017eavnosti",
+        "date": "2027-05-30"
+    },
+    {
+        "name": "Dan antifa\u0161isti\u010dke borbe",
+        "date": "2027-06-22"
+    },
+    {
+        "name": "Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja",
+        "date": "2027-08-05"
+    },
+    {
+        "name": "Velika Gospa",
+        "date": "2027-08-15"
+    },
+    {
+        "name": "Svi sveti",
+        "date": "2027-11-01"
+    },
+    {
+        "name": "Dan sje\u0107anja na \u017ertve Domovinskog rata i Dan sje\u0107anja na \u017ertvu Vukovara i \u0160kabrnje",
+        "date": "2027-11-18"
+    },
+    {
+        "name": "Bo\u017ei\u0107",
+        "date": "2027-12-25"
+    },
+    {
+        "name": "Sveti Stjepan",
+        "date": "2027-12-26"
+    }
+]

--- a/tests/Countries/CroatiaTest.php
+++ b/tests/Countries/CroatiaTest.php
@@ -5,14 +5,14 @@ namespace Spatie\Holidays\Tests\Countries;
 use Carbon\CarbonImmutable;
 use Spatie\Holidays\Holidays;
 
-it('can calculate croatian holidays', function () {
-    CarbonImmutable::setTestNow('2024-01-01');
+it('can calculate croatian holidays', function (int $year) {
+    CarbonImmutable::setTestNow("{$year}-01-01");
 
-    $holidays = Holidays::for(country: 'hr')->get();
+    $holidays = Holidays::for(country: 'hr', year: $year)->get();
 
     expect($holidays)
         ->toBeArray()
         ->not()->toBeEmpty();
 
     expect(formatDates($holidays))->toMatchSnapshot();
-});
+})->with([2024, 2025, 2026, 2027]);


### PR DESCRIPTION
  Fixes two issues with Croatian public holidays:
  - **Missing** `Uskrs` (Easter Sunday) -> listed in the Public Holidays Act and on the source of truth, but absent from `Croatia.php`.
  - **Wrong name** for Epiphany: `Bogojavljenje` → `Bogojavljenje ili Sveta tri kralja`, matching the official name in *Zakon o blagdanima, spomendanima i neradnim danima u Republici Hrvatskoj*.

  Source of truth: https://neradni-dani.com/neradni-dani-2026.php

